### PR TITLE
Disallow mixing host tasks with kernel invocations

### DIFF
--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -35,7 +35,9 @@ For example, a SYCL runtime may decide to map / unmap instead of copy operations
 or  performing asynchronous transfers while data is being computed.
 
 It is possible to run multiple host tasks in the same command group - the host
-tasks are executed in-order within the command group.
+tasks are executed in-order within the command group. It is not possible to use
+host tasks and kernel invocations (e.g. `parallel_for`) in the same command
+group.
 
 ```cpp
     auto cgH = [=] (handler& h) {


### PR DESCRIPTION
Since there can currently only be one kernel per command group, there are certain expectations that need to be met and it would be difficult to meet them if host tasks were allowed alongside kernel invocations in the same command group. So until the limit of one kernel per group is lifted, this should should be disallowed, i.e. even though multiple host tasks per command group are allowed, also using a kernel invocation in the same command group should not be.