### PR TITLE
Changes for updating data to/from device

### DIFF
--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -78,8 +78,8 @@ without blocking the execution.
     auto cgH = [=] (handler& h) {
       auto accA = bufA.get_access<access::mode::read>(h);
       h.parallel_for<class kernel>(range, SomeKernel(accA));
-      h.update_from_device(accA, hostPtr);
-      };
+      h.update_from_device(hostPtr, accA);
+    };
     qA.submit(cgH);
 ```
 
@@ -104,7 +104,7 @@ qA.submit(cgH);
 |--------|-------------|
 | `template <typename AccessorT> void update_from_device(AccessorT acc)`  | Updates the pointer associated with the buffer or image on the host. |
 | `template <typename AccessorT> void update_to_device(AccessorT acc)`  | Updates the data in accessor `acc` with the data associated with it on the host. |
-| `template <typename AccessorT, typename T> void update_from_device(AccessorT acc, shared_ptr<T> hostPtr)`  | Update the contents of the host pointer with the data in accessor `acc`. `hostPtr` must have enough space allocated to hold the data. |
+| `template <typename T, typename AccessorT> void update_from_device(shared_ptr<T> hostPtr, AccessorT acc)`  | Update the contents of the host pointer with the data in accessor `acc`. `hostPtr` must have enough space allocated to hold the data. |
 | `template <typename AccessorT, typename T> void update_to_device(AccessorT acc, shared_ptr<T> hostPtr)` | Update the the data in accessor `acc` with the contents of the host pointer. `hostPtr` must have enough space allocated to hold the data. |
-| `template <typename AccessorT, typename OutputIterator> void update_from_device(AccessorT acc, OutputIterator ot)` | Write the contents of the memory pointed to by `acc` into the output iterator `ot`.  |
+| `template <typename OutputIterator, typename AccessorT> void update_from_device(OutputIterator ot, AccessorT acc)` | Write the contents of the memory pointed to by `acc` into the output iterator `ot`.  |
 | `template <typename AccessorT, typename InputIterator> void update_to_device(AccessorT acc, InputIterator it)` | Write the contents of the input iterator `it` into the memory pointed to by `acc`.  |

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -86,8 +86,7 @@ without blocking the execution.
 Note that the users can query the event returned by the submit to check if the
 command group has finished (and, therefore, the host pointer has been updated).
 
-Additionally, users may want to manually update the device data with some host
-data.
+Additionally, users may want to manually update the device data with host data.
 
 ```cpp
 auto cgH = [=] (handler& h) {
@@ -100,17 +99,17 @@ qA.submit(cgH);
 
 #### Access restrictions
 
-There are a few restrictions on the access mode and target of the accessor
-supplied to `update_from_device` and `update_to_device`.
+The following restrictions apply to access mode and target of the accessor
+provided to `update_from_device` and `update_to_device`.
 
 Because a call to `update_from_device` triggers a read from the device data, the
-accessor access mode can only be one of the following:
+only valid accessor modes are the following:
 * `access::mode::read`
 * `access::mode::read_write`
 * `access::mode::discard_read_write`
 
 Similarly, because a call to `update_to_device` triggers a write to the device
-data, the accessor access mode can only be one of the following:
+data, the only valid accessor modes are the following:
 * `access::mode::write`
 * `access::mode::read_write`
 * `access::mode::discard_write`

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -98,6 +98,24 @@ auto cgH = [=] (handler& h) {
 qA.submit(cgH);
 ```
 
+#### Access restrictions
+
+There are a few restrictions on the access mode and target of the accessor
+supplied to `update_from_device` and `update_to_device`.
+
+Because a call to `update_from_device` triggers a read from the device data, the
+accessor access mode can only be one of the following:
+* `access::mode::read`
+* `access::mode::read_write`
+* `access::mode::discard_read_write`
+
+Similarly, because a call to `update_to_device` triggers a write to the device
+data, the accessor access mode can only be one of the following:
+* `access::mode::write`
+* `access::mode::read_write`
+* `access::mode::discard_write`
+* `access::mode::discard_read_write`
+
 #### API changes
 
 | Method | Description |

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -86,10 +86,25 @@ without blocking the execution.
 Note that the users can query the event returned by the submit to check if the
 command group has finished (and, therefore, the host pointer has been updated).
 
+Additionally, users may want to manually update the device data with some host
+data.
+
+```cpp
+auto cgH = [=] (handler& h) {
+  auto accA = bufA.get_access<access::mode::read_write>(h);
+  h.update_to_device(accA, hostPtr);
+  h.parallel_for<class kernel>(range, SomeKernel(accA));
+};
+qA.submit(cgH);
+```
+
 #### API changes
 
 | Method | Description |
 |--------|-------------|
-| `cpp template<typename AccessorT, typename T> void update_from_device(AccessorT acc)`  | Updates the pointer associated with the buffer or image on the host. |
-| `cpp template<typename AccessorT, typename T> void update_from_device(AccessorT acc, shared_ptr<T> hostPtr)`  | Update the contents of the host pointer with the data in accessor _acc_. _hostPtr_ must have enough space allocated to hold the data. |
-| `template<typename AccessorT, typename OutputIterator> void update_from_device(AccessorT acc, OutputIterator ot)`  | Write the contents of the memory pointed by _acc_ into the OutputIterator _ot_  |
+| `template <typename AccessorT> void update_from_device(AccessorT acc)`  | Updates the pointer associated with the buffer or image on the host. |
+| `template <typename AccessorT> void update_to_device(AccessorT acc)`  | Updates the data in accessor `acc` with the data associated with it on the host. |
+| `template <typename AccessorT, typename T> void update_from_device(AccessorT acc, shared_ptr<T> hostPtr)`  | Update the contents of the host pointer with the data in accessor `acc`. `hostPtr` must have enough space allocated to hold the data. |
+| `template <typename AccessorT, typename T> void update_to_device(AccessorT acc, shared_ptr<T> hostPtr)` | Update the the data in accessor `acc` with the contents of the host pointer. `hostPtr` must have enough space allocated to hold the data. |
+| `template <typename AccessorT, typename OutputIterator> void update_from_device(AccessorT acc, OutputIterator ot)` | Write the contents of the memory pointed to by `acc` into the output iterator `ot`.  |
+| `template <typename AccessorT, typename InputIterator> void update_to_device(AccessorT acc, InputIterator it)` | Write the contents of the input iterator `it` into the memory pointed to by `acc`.  |

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -102,9 +102,9 @@ qA.submit(cgH);
 
 | Method | Description |
 |--------|-------------|
-| `template <typename AccessorT> void update_from_device(AccessorT acc)`  | Updates the pointer associated with the buffer or image on the host. |
-| `template <typename AccessorT> void update_to_device(AccessorT acc)`  | Updates the data in accessor `acc` with the data associated with it on the host. |
-| `template <typename T, typename AccessorT> void update_from_device(shared_ptr<T> hostPtr, AccessorT acc)`  | Update the contents of the host pointer with the data in accessor `acc`. `hostPtr` must have enough space allocated to hold the data. |
-| `template <typename AccessorT, typename T> void update_to_device(AccessorT acc, shared_ptr<T> hostPtr)` | Update the the data in accessor `acc` with the contents of the host pointer. `hostPtr` must have enough space allocated to hold the data. |
-| `template <typename OutputIterator, typename AccessorT> void update_from_device(OutputIterator ot, AccessorT acc)` | Write the contents of the memory pointed to by `acc` into the output iterator `ot`.  |
-| `template <typename AccessorT, typename InputIterator> void update_to_device(AccessorT acc, InputIterator it)` | Write the contents of the input iterator `it` into the memory pointed to by `acc`.  |
+| `template <typename T, int dims, access::mode accessMode, access::target accessTarget> void update_from_device(accessor<T, dims, accessMode, accessTarget> acc)`  | Updates the pointer associated with the buffer or image on the host. |
+| `template <typename T, int dims, access::mode accessMode, access::target accessTarget> void update_to_device(accessor<T, dims, accessMode, accessTarget> acc)`  | Updates the data in accessor `acc` with the data associated with it on the host. |
+| `template <typename T, int dims, access::mode accessMode, access::target accessTarget> void update_from_device(shared_ptr<T> hostPtr, accessor<T, dims, accessMode, accessTarget> acc)`  | Update the contents of the host pointer with the data in accessor `acc`. `hostPtr` must have enough space allocated to hold the data. |
+| `template <typename T, int dims, access::mode accessMode, access::target accessTarget> void update_to_device(accessor<T, dims, accessMode, accessTarget> acc, shared_ptr<T> hostPtr)` | Update the the data in accessor `acc` with the contents of the host pointer. `hostPtr` must have enough space allocated to hold the data. |
+| `template <typename OutputIterator, typename T, int dims, access::mode accessMode, access::target accessTarget> void update_from_device(OutputIterator ot, accessor<T, dims, accessMode, accessTarget> acc)` | Write the contents of the memory pointed to by `acc` into the output iterator `ot`.  |
+| `template <typename T, int dims, access::mode accessMode, access::target accessTarget, typename InputIterator> void update_to_device(accessor<T, dims, accessMode, accessTarget> acc, InputIterator it)` | Write the contents of the input iterator `it` into the memory pointed to by `acc`.  |


### PR DESCRIPTION
* Added `update_to_device` API call, along with an example
* Changed the order of arguments for `update_from_device` so that it follows `std::memcpy` (first argument destination, second one source)
* Made the type of the accessor passed to these functions more verbose
* Restrictions on the access mode and access target for the accessor passed to these functions