### PR TITLE
Updated buffer properties proposal

### DIFF
--- a/tied-buffer/index.md
+++ b/tied-buffer/index.md
@@ -13,11 +13,11 @@
 
 ## Overview
 
-This proposal aims to define an interface for specialising the buffer class whilst still allowing buffers of different types to be stored in a generic container, via the use of buffer tags.
+This proposal aims to define an interface for specialising the buffer class whilst still allowing buffers of different types to be stored in a generic container, via the use of buffer properties.
 
 ## Versions
 
 | Version | Last Modified | Document |
 |---------|----- | ---------|
-| Buffer tied to a Context | 19 April 2017 | [Link](sycl-2.2/tied-buffer.md) |
-| Buffer Tags | 31 May 2017 | [Link](sycl-2.2/buffer-tags.md) |
+| Buffer tied to a Context | 9 Jun 2017 | [Link](sycl-2.2/tied-buffer.md) |
+| Buffer Tags | 9 Jun 2017 | [Link](sycl-2.2/buffer-tags.md) |

--- a/tied-buffer/sycl-2.2/buffer-properties.cpp
+++ b/tied-buffer/sycl-2.2/buffer-properties.cpp
@@ -1,0 +1,118 @@
+class buffer_allocator { int i; };
+class custom_allocator {};
+class context {};
+
+namespace prop {
+
+struct svm {};
+struct use_host_ptr {};
+struct context_bound {
+  context_bound(context &c)
+    : m_context(c) {}
+
+  context get_context() { return m_context; }
+
+  context m_context;
+};
+
+}
+
+enum class __property_enum {
+  allocator = 0,
+  use_host_ptr = 1,
+  context_bound = 2,
+  svm = 3
+};
+
+template <typename propT>
+struct __get_property_enum {
+  static const __property_enum value = __property_enum::allocator;
+};
+
+template <>
+struct __get_property_enum<prop::use_host_ptr> {
+  static const __property_enum value = __property_enum::use_host_ptr;
+};
+
+template <>
+struct __get_property_enum<prop::context_bound> {
+  static const __property_enum value = __property_enum::context_bound;
+};
+
+template <>
+struct __get_property_enum<prop::svm> {
+  static const __property_enum value = __property_enum::svm;
+};
+
+template <typename dataT, int kElems, typename allocatorT = buffer_allocator>
+class buffer {
+public:
+  template <typename... propTN>
+  buffer(propTN... properties) {
+    process_properties(properties...);
+  }
+
+  template <typename propT, typename... propTN>
+  void process_properties(propT prop, propTN... properties) {
+    constexpr property_enum e = __get_property_enum<propT>::value;
+    m_hasProperty[static_cast<int>(e)] = true;
+    process_property(prop);
+    process_properties(properties...);
+  }
+
+  void process_properties() {
+  }
+
+  void process_property(prop::context_bound prop) {
+    m_context = prop.get_context();
+  }
+
+  void process_property(prop::use_host_ptr prop) {
+  }
+
+  void process_property(prop::svm prop) {
+  }
+
+  void process_property(allocatorT prop) {
+    m_allocator = prop;
+  }
+
+  template <typename propT>
+  bool has_property() {
+    constexpr property_enum e = __get_property_enum<propT>::value;
+    return m_hasProperty[static_cast<int>(e)];
+    }
+
+private:
+
+  bool m_hasProperty[4];
+  context m_context;
+  allocatorT m_allocator;
+};
+
+int main () {
+
+  context myContext;
+
+  std::vector<buffer<int, 1>> bufferList;
+
+  bufferList.push_back(buffer<int, 1>());
+  bufferList.push_back(buffer<int, 1>(prop::use_host_ptr()));
+  bufferList.push_back(buffer<int, 1>(prop::context_bound(myContext)));
+  bufferList.push_back(buffer<int, 1>(prop::svm()));
+  bufferList.push_back(buffer<int, 1>(buffer_allocator{}, prop::context_bound(myContext)));
+
+  std::vector<buffer<int, 1, std::allocator<int>>> customBufferList;
+  customBufferList.push_back(buffer<int, 1, std::allocator<int>>());
+  customBufferList.push_back(buffer<int, 1, std::allocator<int>>(prop::use_host_ptr()));
+
+  for(auto& buf : bufferList) {
+    if (buf.has_property<prop::use_host_ptr>()) {
+      // ...
+    } else if (buf.has_property<prop::svm>()) {
+      // ...
+    } else if (buf.has_property<prop::context_bound>()) {
+      // ...
+    }
+  }
+ }

--- a/tied-buffer/sycl-2.2/buffer-tags.md
+++ b/tied-buffer/sycl-2.2/buffer-tags.md
@@ -14,6 +14,9 @@
 
 This proposal aims to define an interface for specialising the construction of the buffer class whilst still allowing buffers of different types to be stored in a generic container, via the use of buffer tags. 
 Each tag represent a different property of a buffer.
+By defining properties for buffers and enabling expressing them independently from the
+buffer API we simplify the SYCL specification and we enable future capabilities to be added
+seamlessly. 
 
 ## Revisions
 
@@ -98,7 +101,7 @@ class buffer {
 
 ## Defined properties
 
-### SYCL 1.2.1 
+### Extension to SYCL 1.2
 
 * *map_ptr*: Buffer will use the given pointer exclusively for host access.
 
@@ -106,6 +109,8 @@ class buffer {
 struct map_ptr {
 
   map_ptr() = default;
+
+  // Implementation defined members
 };
 ```
 
@@ -113,11 +118,11 @@ struct map_ptr {
 
 ```cpp
 struct cl_interop {
-  ...
   // Construct a property for interoperability
-  cl_interop(cl_mem clMemObject) { }
-  // Retrieves the OpenCL memory object
-  cl_mem get_cl_mem();
+  cl_interop(cl_mem clMemObject, cl::sycl::event event, cl::sycl::queue q) {
+      // implementation defined
+   }
+  // Implementation defined members
 };
 ```
 
@@ -127,18 +132,20 @@ struct cl_interop {
 ```cpp
 struct gl_interop {
   gl_interop() = default;
+  // Implementation defined members
 };
 ```
 
 ### SYCL 2.2
 
-All the SYCL 1.2.1 properties plus:
+All the previous extension properties plus:
 
 * *svm*: The buffer is used for SVM allocation purposes
 
 ```cpp
 struct svm {
-  svm() = default;
+  svm(SVM) = default;
+  // Implementation defined members
 };
 ```
 
@@ -156,10 +163,11 @@ int main() {
   bufferList.push_back(buffer<int, 1>(hostPtr, range));
   // Buffer that is maping a host pointer with the device
   bufferList.push_back(buffer<int, 1>(hostPtr, range, 
-                                      property::map));
+                                      property::map()));
   // Buffer using an interop constructor
   bufferList.push_back(buffer<int, 1>(hostPtr, range, 
-                                      property::cl_interop(clMemObject)));
+                                      property::cl_interop(clMemObject, 
+                                                           clEvent, syclQueue)));
 
   for(auto& buf : bufferList) {
     if (buf.has_property<property::cl_interop>())) {

--- a/tied-buffer/sycl-2.2/buffer-tags.md
+++ b/tied-buffer/sycl-2.2/buffer-tags.md
@@ -14,7 +14,7 @@
 
 This proposal aims to define an interface for specialising the construction of the buffer class whilst still allowing buffers of different types to be stored in a generic container, via the use of buffer tags. 
 Each tag represent a different property of a buffer.
-By defining properties for buffers and enabling expressing them independently from the
+By defining properties for buffers and allowing them to be expressed independently from the
 buffer API we simplify the SYCL specification and we enable future capabilities to be added
 seamlessly. 
 
@@ -64,7 +64,7 @@ With this interface, a user can specify a specialisation of the buffer class by 
 
 ```cpp
 namespace property {
-  struct map_ptr;
+  struct map;
   struct cl_interop;
   struct gl_interop;
   struct svm;  // SYCL 2.2 Only

--- a/tied-buffer/sycl-2.2/tied-buffer.md
+++ b/tied-buffer/sycl-2.2/tied-buffer.md
@@ -39,10 +39,14 @@ buffer and this context-specific variant:
 ```cpp
 struct context_bound {
   context_bound(cl::sycl::context context);
+
+  cl::sycl::context get_context();
 };
+```
 
-All the API interface for the normal buffers is available.
-
+Tied buffers have the same methods than the generic buffers, plus
+an extra *get\_context()* method that retrieves the context associated
+with the buffer.
 
 ```cpp
 template<typename T, int dim,
@@ -55,11 +59,8 @@ class buffer {
 };
 ```
 
-Note that in this case we can offer a `get_context` method for the memory
-object, that returns the SYCL context that this `tied_buffer` is associated
-with.
-
-In case of an error, the `runtime_error` exception should be thrown.
+In case of an error, such as a tied buffer being used on the wrong
+context, the `runtime_error` exception should be thrown.
 
 ## Shared Virtual Memory support
 

--- a/tied-buffer/sycl-2.2/tied-buffer.md
+++ b/tied-buffer/sycl-2.2/tied-buffer.md
@@ -44,21 +44,6 @@ struct context_bound {
 };
 ```
 
-Tied buffers have the same methods than the generic buffers, plus
-an extra *get\_context()* method that retrieves the context associated
-with the buffer.
-
-```cpp
-template<typename T, int dim,
-          typename AllocatorT = cl::sycl::buffer_allocator<T>>
-class buffer {
-  public:
-
-// Additional method with property context_bound
-    context get_context() const;
-};
-```
-
 In case of an error, such as a tied buffer being used on the wrong
 context, the `runtime_error` exception should be thrown.
 
@@ -114,7 +99,7 @@ std::experimental::for_each(sycl_named_policy<example>(otherQueue),
  * performed.
  */
 buffer<float, 1> tmp{deviceContext, myRange, 
-                     buffer::property::context_bound(deviceContext)};
+                     property::buffer::context_bound(deviceContext)};
 
 bool firstIter = true;
 

--- a/tied-buffer/sycl-2.2/tied-buffer.md
+++ b/tied-buffer/sycl-2.2/tied-buffer.md
@@ -15,23 +15,31 @@
 This proposal aims to offer a buffer object that is tied to a specific SYCL 
 context, which allow  users to provide extra information to the SYCL 
 implementation to optimize usage for a single context and device.
-This concept vagely exists when using Shared Virtual Memory constructors
+This concept vaguely exists when using Shared Virtual Memory constructors
 on buffers, but it is defined as a specific use case for SVM buffers.
 With a specific `tied_buffer` class we aim to take advantage of
 the lower-overhead of a single-context buffer and simplify the 
 usage of SVM memory on SYCL 2.2
 
+## Revisions
+
+This revision uses buffer properties instead of a separate buffer
+class to describe the behaviour of the tied buffer.
+
 ## Interface changes
 
-This proposal adds a new type of buffer, called `tied_buffer` which
-constructs a SYCL buffer that is tied to only one context, and therefore
-will only be accessible from queues that are associated with that context.
-The `tied_buffer` is derived from the `buffer` class to enable creating 
-collections of both types of buffers. However, methods are not inherited
-publicly to enforce type safety across buffer types.
+This proposal adds a new property for buffers, *buffer::property::context\_bound*.
+A SYCL buffer with the *context bound* property can only be used with one context,
+and its values are only accessible from queues that are associated with
+said context.
 
-A separate buffer type makes a clear distintion between the normal SYCL
-buffer and this context-specific variant.
+A separate buffer property makes a clear distinction between the normal SYCL
+buffer and this context-specific variant:
+
+```cpp
+struct context_bound {
+  context_bound(cl::sycl::context context);
+};
 
 All the API interface for the normal buffers is available.
 
@@ -39,63 +47,17 @@ All the API interface for the normal buffers is available.
 ```cpp
 template<typename T, int dim,
           typename AllocatorT = cl::sycl::buffer_allocator<T>>
-class tied_buffer : protected buffer <T, AllocatorT> {
-
+class buffer {
   public:
-    tied_buffer(context& syclContext, T * hostPointer, 
-                const range<dim> bufferRange,
-                AllocatorT allocator = {});
 
-    tied_buffer(context& syclContext, const T * hostPointer, 
-                const range<dim> bufferRange,
-                AllocatorT allocator = {});
-
-    tied_buffer(context& syclContext, shared_ptr_class<T> hostData,
-                const range<dim> bufferRange,
-                const AllocatorT allocator = {});
-
-    tied_buffer(context& syclContext, 
-                const range<dimensions> &bufferRange,
-                AllocatorT allocator = {});
-
-    template<typename OAllocatorT = AllocatorT>
-    tied_buffer(context& syclContext, tied_buffer<T, dim, OAllocatorT> &tb,
-                const id<dimensions> &baseIndex,
-                const range<dimensions> &subRange,
-                AllocatorT allocator = {});
-
-    tied_buffer<T, 1, AllocatorT)(context& syclContext,
-                InputIterator first, InputIterator last,
-                AllocatorT allocator = {});
-
-    tied_buffer(const tied_buffer<T, dim, AllocatorT> &rhs);
-
-    ~tied_buffer();
-
-    size_t get_count() const;
-
-    size_t get_size() const;
-
-    AllocatorT get_allocator() const;
-
+// Additional method with property context_bound
     context get_context() const;
-
-		template <access::mode mode, access::target target = access::global_buffer>
-			accessor<T, dimensions, mode, target> get_access(
-					handler &command_group_handler);
-		template <access::mode mode, access::target target = access::host_buffer>
-			accessor<T, dimensions, mode, target> get_access();
-		void set_final_data(weak_ptr_class<T> &finalData);
 };
 ```
 
 Note that in this case we can offer a `get_context` method for the memory
 object, that returns the SYCL context that this `tied_buffer` is associated
 with.
-
-The interface of the SYCL buffer requires certain changes to 
-implement the inheritance: 
-The destructor of the buffer must be marked `virtual` and `override`.
 
 In case of an error, the `runtime_error` exception should be thrown.
 
@@ -113,8 +75,9 @@ has happened, and may expect the data on the SVM pointer to be valid.
 When passing the buffer across libraries, this situation may occur
 even without the user knowledge.
 
-By enabling the usage of the `svm_allocator` only with the `tied_buffer`
-type, we avoid accidental invalidation of SVM pointers by presenting
+By enabling the usage of the `svm_allocator` only in buffers with
+the  `context_bound` property, 
+we avoid accidental invalidation of SVM pointers by presenting
 a clear differentiation between a buffer tied to a context
 and a buffer that can move across multiple ones.
 
@@ -149,7 +112,8 @@ std::experimental::for_each(sycl_named_policy<example>(otherQueue),
  * on the context where the operation will be
  * performed.
  */
-tied_buffer<float, 1> tmp{deviceContext, myRange};
+buffer<float, 1> tmp{deviceContext, myRange, 
+                     buffer::property::context_bound(deviceContext)};
 
 bool firstIter = true;
 
@@ -184,16 +148,13 @@ do {
 
 An implementation may decide to not take advantage of this hint and 
 simply construct a normal buffer object underneath.
-However, if the tied buffer is used on an invalid context, this must
+However, if the bound buffer is used on an invalid context, this must
 raise an error.
 
 ## Alternative implementations
 
-Alternatively to a derived class from the buffer, we could explore
-other options for the interface, such as a different allocator type
-or a template specialization for the buffer constructor.
-However, these other alternative interface changes have larger impact
-on the specification, so they are left from this proposal at this point.
+The original approach was to use a derived class, but has now
+been updated to use the new properties mechanism.
 
 ## References
 


### PR DESCRIPTION
The buffer tags are now buffer properties.
Buffer properties can take parameters, which simplifies the interface
and enables adding extensions.

The tied-buffer proposal has been refurbished to work with properties
instead of derived classes.