### PR TITLE
Fill pattern size restrictions

### DIFF
--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -151,9 +151,10 @@ The example shows how to fill buffer A contents with an scalar.
 Note that at least write access is required.
 
 ```cpp
+int pattern = 10;
 auto cgH = [=] (handler& h) {
   auto accA = bufA.get_access<access::mode::write>(h);
-  h.fill(accA, 10);
+  h.fill(accA, pattern);
 };
 qA.submit(cgH);
 ```

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -158,6 +158,10 @@ auto cgH = [=] (handler& h) {
 qA.submit(cgH);
 ```
 
+Because of device restrictions on the size of the pattern, the size in bytes of
+the data type used for the pattern must be one of 1, 2, 4, 8, 16, 32, 64,
+or 128.
+
 #### Access restrictions
 
 The following restrictions apply to access mode and target of the accessor

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -153,7 +153,7 @@ Note that at least write access is required.
 ```cpp
 auto cgH = [=] (handler& h) {
   auto accA = bufA.get_access<access::mode::write>(h);
-  h.fill(accB, 10);
+  h.fill(accA, 10);
 };
 qA.submit(cgH);
 ```

--- a/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
+++ b/asynchronous-data-flow/sycl-2.2/03_interacting_with_data_on_the_host.md
@@ -159,9 +159,9 @@ auto cgH = [=] (handler& h) {
 qA.submit(cgH);
 ```
 
-Because of device restrictions on the size of the pattern, the size in bytes of
-the data type used for the pattern must be one of 1, 2, 4, 8, 16, 32, 64,
-or 128.
+Because of restrictions in OpenCL implementations on the size of the pattern,
+the size in bytes of the data type used for the pattern must be one of 1, 2, 4,
+8, 16, 32, 64, or 128.
 
 #### Access restrictions
 


### PR DESCRIPTION
In the documentation for [`clEnqueueFillBuffer` ](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clEnqueueFillBuffer.html), the pattern size needs to be one of 1, 2, 4, 8, 16, 32, 64, 128. It makes sense to have this restriction for the `fill` function as well because enabling it in the general case would be very inefficient.

Also fixed an accessor name typo.