### PR TITLE
d0796r1: Fix "Background Research..." section

### DIFF
--- a/affinity/cpp-20/d0796r1.md
+++ b/affinity/cpp-20/d0796r1.md
@@ -4,11 +4,11 @@
 
 **Audience: SG1, SG14**
 
-**Authors: Gordon Brown, Ruyman Reyes, Michael Wong, H. Carter Edwards, Thomas Rodgers**
+**Authors: Gordon Brown, Ruyman Reyes, Michael Wong, H. Carter Edwards, Thomas Rodgers, Mark Hoemmen**
 
-**Contributors: Patrice Roy, Jeff Hammond, Mark Hoemmen**
+**Contributors: Patrice Roy, Jeff Hammond**
 
-**Emails: gordon@codeplay.com, ruyman@codeplay.com, michael@codeplay.com, hcedwar@sandia.gov, rodgert@twrodgers.com**
+**Emails: gordon@codeplay.com, ruyman@codeplay.com, michael@codeplay.com, hcedwar@sandia.gov, rodgert@twrodgers.com, mhoemme@sandia.gov**
 
 **Reply to: michael@codeplay.com**
 
@@ -62,7 +62,7 @@ The goal was that this would enable scaling up for heterogeneous and distributed
 
 # Background Research: State of the Art
 
-The problem of effectively partitioning a system’s topology is one which has been so for some time, and there are a range of third party libraries / standards which provides APIs to solve the problem. In order to standardise this process for C++ we must carefully look at all of these approaches and identify which we wish to adopt. Below is a list of the libraries and standards which this proposal will draw from:
+The problem of effectively partitioning a system’s topology has existed for some time, and there are a range of third-party libraries and standards which provide APIs to solve the problem. In order to standardize this process for C++, we must carefully look at all of these approaches and identify which we wish to adopt. Below is a list of the libraries and standards from which this proposal will draw:
 
 * [Portable Hardware Locality][hwloc]
 * [SYCL 1.2][sycl-1-2-1]
@@ -82,22 +82,22 @@ The problem of effectively partitioning a system’s topology is one which has b
 * [HPX][hpx]
 * [MADNESS][madness]
 
-Libraries such as the Portable Hardware Locality (hwloc) [9] provide a low level of hardware abstraction and offer a solution for the portability problem by supporting many platforms and operating systems. This and similar approaches may provide detailed hardware information in a tree-like structure. However, even some current systems cannot be represented correctly by a tree, where the number of hops between two sockets vary between socket pairs [14].
+Libraries such as the Portable Hardware Locality (hwloc) library [9] provide a low level of hardware abstraction, and offer a solution for the portability problem by supporting many platforms and operating systems. This and similar approaches use a tree structure to represent details of CPUs and the memory system. However, even some current systems cannot be represented correctly by a tree, if the number of hops between two sockets varies between socket pairs [14].
 
-Some systems will provide additional user control through explicit binding of threads to processors through environment variables consumed by various compilers, system commands (e.g. Linux: taskset, numactl; Windows: start /affinity), or system calls for example Solaris has `pbind()`, Linux has `sched_setaffinity()` and Windows has `SetThreadAffinityMask()`.
+Some systems give additional user control through explicit binding of threads to processors through environment variables consumed by various compilers, system commands, or system calls.  Examples of system commands include Linux's `taskset` and `numactl`, and Windows' `start /affinity`.  System call examples include Solaris' `pbind()`, Linux's `sched_setaffinity()`, and Windows' `SetThreadAffinityMask()`.
 
 ## Problem Space
 
-In this paper we describe the problem space of affinity for C++, the various challenges which need to be addressed in defining a partitioning and affinity interface for C++ and some suggested solutions:
+In this paper we describe the problem space of affinity for C++, the various challenges which need to be addressed in defining a partitioning and affinity interface for C++, and some suggested solutions.  These include:
 
-* How to represent, identify and navigate the topology of execution resources available within a heterogeneous or distributed system.
-* How to query and measure the relative affininty between different execution resources within a system.
-* How to bind execution and allocation particular execution resource(s).
-* What kind of and level of interface(s) should be provided by C++ for affinity.
+* How to represent, identify and navigate the topology of execution resources available within a heterogeneous or distributed system
+* How to query and measure the relative affinity between different execution resources within a system
+* How to bind execution and allocation to particular execution resource(s)
+* What kind of and level of interface(s) should be provided by C++ for affinity
 
-Wherever possible, we also evaluate how an affinity based solution could be scaled to support both distributed and heterogeneous systems.
+Wherever possible, we also evaluate how an affinity-based solution could be scaled to support both distributed and heterogeneous systems.
 
-There are some additional challenges which we have been investigating but are not yet ready to be included in this paper and will be presented in a future paper:
+Here are additional challenges which we have been investigating but are not yet ready to be included in this paper, and which will be presented in a future paper:
 
 * Migrating data from memory allocated in one partition to another
 * Defining memory placement algorithms or policies


### PR DESCRIPTION
In d0796r1, fix grammar and wording in "Background Research: State of the Art" section.