### PR TITLE
Updates to split execution and memory resources, reduce scope

### DIFF
--- a/affinity/cpp-20/d0796r2.md
+++ b/affinity/cpp-20/d0796r2.md
@@ -12,6 +12,8 @@
 
 **Reply to: gordon@codeplay.com**
 
+**Status: Exploratory**
+
 # Changelog
 
 ### P0796r2 (RAP)
@@ -129,7 +131,7 @@ Nowadays, there are various APIs and libraries that enable this functionality. O
 
 ![alt text](hwloc-topology.png "Hwloc topology")
 
-The interface of `thread_execution_resource_t` proposed in the execution context proposal [[23]][p0737r0] proposes a hierarchical approach where there is a root resource and each resource has a number of child resources. 
+The interface of `thread_execution_resource` proposed in the execution context proposal [[23]][p0737r0] proposes a hierarchical approach where there is a root resource and each resource has a number of child resources. 
 
 Some heterogeneous systems execution and memory resources are not naturally represented by a single tree [[24]][exposing-locality]. The HSA standard solves this problem by allowing a node in the topology to have multiple parent nodes [19].
 
@@ -207,105 +209,78 @@ to the state of a single executing callable; *e.g.*,
 program counter, registers, stack frame. *--end note*]
 
 The **concurrency** of an execution resource is an upper bound of the
-number of execution agents that could make concurrent forward progress 
+number of execution agents that could concurrently make forward progress 
 on that execution resource. 
 It is guaranteed that no more than **concurrency** execution agents 
 could make concurrent forward progress; it is not guaranteed that
-**concurrency** execution agents will ever make concurrent forward progress.
+**concurrency** execution agents will ever concurrently make forward progress.
 
-### Execution resources
+The **affinity** between an execution resource and memory resource
+is an upper bound of the uncontended bandwidth or latency 
+between an execution agent running on the execution resource and
+memory allocated from the memory resource.
 
-An `execution_resource` is a lightweight structure which acts as an identifier to particular piece of hardware within a system. It can be queried for whether it can allocate memory via `can_place_memory`, whether it can execute work via `can_place_agents`, and for its name via `name`. An `execution_resource` can also represent other `execution_resource`s. We call these *members of* that `execution_resource`, and can be queried via `resources`. Additionally the `execution_resource` which another is a *member of* can be queried vis `member_of`. An `execution_resource` can also be queried for the concurrency it can provide, the total number of *threads of execution* supported by that *execution_resource*, and all resources it represents.
-
-> [*Note:* Note that an execution resource is not limited to resources which execute work, but also a general resource where no execution can take place but memory can be allocated such as off-chip memory. *--end note*]
-
-> [*Note:* The intention is that the actual implementation details of a resource topology are described in an execution context when required. This allows the execution resource objects to be lightweight objects that serve as identifiers that are only referenced. *--end note*]
 
 ### System topology
 
-The system topology is made up of a number of system-level `execution_resource`s, which can be queried through `this_system::get_resources` which returns a `std::vector`. A run-time library may initialize the `execution_resource`s available within the system dynamically. However, this must be done before `main` is called, given that after that point, the system topology may not change.
+A *system* includes execution resources and memory resources.
+Execution resources are organized hierarchically.
+A particular execution resource may be a partitioned into
+a collection of execution resources referred to as *members of*
+that execution resource.
+The partitioning of execution resources implies a locality relationship;
+*e.g.*, if `{{A,B},{C,D}}` is a hierarchical partitioning then
+`A` is more local to `B` than it is to `C` or `D`.
 
-Below *(Listing 2)* is an example of iterating over the system-level resources and printing out their capabilities.
+An execution resource has one or more memory resources 
+which can allocate memory accessible to that execution resource.
+When an execution resource hierarchy is traversed the associated
+memory resources equal or greater affinity than memory resources
+associated with the coarser execution resource.
 
 ```cpp
-for (auto res : execution::this_system::get_resources()) {
-    std::cout << res.name()  `\n`;
-    std::cout << res.can_place_memory() << `\n`;
-    std::cout << res.can_place_agents() << `\n`;
-    std::cout << res.concurrency() << `\n`;
+size_t count = 0 ;
+for (auto member : execution::this_system::execution_resource()) {
+    count += member.concurrency();
+    std::cout << member.name()  `\n`;
+    std::cout << member.concurrency() << `\n`;
 }
+assert( count == execution::this_system::execution_resource().concurrency() );
 ```
 *Listing 2: Example of querying all the system level execution resources*
 
-### Current resource
-
-The `execution_resource` which underlies the current thread of execution can be queried through `this_thread::get_resource`.
+> [*Note:* The intention is that the actual implementation details of a resource topology are described in an execution context when required. This allows the execution resource objects to be lightweight objects that serve as identifiers that are only referenced. *--end note*]
 
 ### Querying relative affinity
 
 The `affinity_query` class template provides an abstraction for a relative affinity value between an execution resource and a memory resource, derived from a particular `affinity_operation` and `affinity_metric`. The `affinity_query` is templated by `affinity_operation` and `affinity_metric` and is constructed from an execution resource and memory resource. An `affinity_query` does not mean much on it's own, instead a relative magnitude of affinity can be queried by using comparison operators. If nessesary the value of an `affinity_query` can also be queried through `native_affinity`, though the return value of this is implementation defined.
 
-Below *(listing 3)* is an example of how to query the relative affinity between two `execution_resource`s.
+Below *(listing 3)* is an example of how you can query the relative affinity between two execution resources.
 
 ```cpp
-auto systemLevelResources = execution::this_system::get_resources();
-auto memberResources = systemLevelResources.resources();
+auto exec0 = *execution::this_system::execution_resource().begin();
+auto exec1 = *++execution::this_system::execution_resource().begin();
+auto mem0  = *exec0.memory_resource().begin();
 
-auto relativeLatency01 = execution::affinity_query<execution::affinity_operation::read,
-  execution::affinity_metric::latency>(memberResources[0], memberResources[1]);
+auto relativeLatency0 = execution::affinity_query<execution::affinity_operation::read,
+  execution::affinity_metric::latency>(exec0,mem0);
 
-auto relativeLatency02 = execution::affinity_query<execution::affinity_operation::read,
-  execution::affinity_metric::latency>(memberResources[0], memberResources[2]);
+auto relativeLatency1 = execution::affinity_query<execution::affinity_operation::read,
+  execution::affinity_metric::la1Gtency>(exec1,mem0);
 
-auto relativeLatency = relativeLatency01 > relativeLatency02;
+auto relativeLatency = relativeLatency0 > relativeLatency1;
 ```
 *Listing 3: Example of querying affinity between two `execution_resource`s.*
 
 > [*Note:* This interface for querying relative affinity is a very low-level interface designed to be abstracted by libraries and later affinity policies. *--end note*]
 
-### Execution context
-
-The `execution_context` class provides an abstraction for managing a number of lightweight execution agents executing work on an `execution_resource` and any `execution_resource`s encapsulated by it. An `execution_context` can then provide an executor for executing work and an allocator or polymorphic memory resource for allocating memory. The `execution_context` is constructed with an `execution_resource`. Then, the `execution_context` may execute work or allocate memory for that `execution_resource` and an `execution_resource` that it represents.
-
-Below *(Listing 4)* is an example of how this extended interface could be used to construct an *execution context* from an *execution resource* which is retrieved from the *system’s resource topology*. Once an *execution context* is constructed it can then still be queried for its *execution resource*, and that *execution resource* can be further partitioned.
-
-```cpp
-auto &resources = execution::this_system::get_resources();
-
-execution::execution_context execContext(resources[0]);
-
-auto &systemLevelResource = execContext.resource();
-
-// resource[0] should be equal to execResource
-
-for (auto res : systemLevelResource.resources()) {
-    std::cout << res.name()  << `\n`;
-}
-```
-*Listing 4: Example of constructing an execution context from an execution resource*
-
 ### Binding execution and allocation to resources
 
-When creating an `execution_context` from a given `execution_resource`, the executors and allocators associated with it are bound to that `execution_resource`. For example, when creating an `execution_resource` from a CPU socket resource, all executors associated with the given socket will spawn execution agents with affinity to the socket partition of the system *(Listing 5)*.
+An execution context, such as a thread pool, may be bound to an execution resource.
+Binding enables multiple execution contexts to be created and bound to disjoint
+execution resources so that their respective execution agents do not compete for
+their respective execution resources.
 
-```cpp
-auto cList = std::execution::this_system::get_resources();
-// FindASocketResource is a user-defined function that finds a 
-// resource that is a CPU socket in the given resource list
-auto& socket = findASocketResource(cList);
-execution_contextC{socket} // Associated with the socket
-auto executor = eC.executor(); // By transitivity, associated with the socket too
-auto socketAllocator = eC.allocator(); // Retrieve an allocator to the closest memory node
-std::vector<int, decltype(socketAllocator)> v1(100, socketAllocator);
-std::generate(par.on(executor), std::begin(v1), std::end(v1), std::rand);
-```
-*Listing 5: Example of allocating with affinity to an execution resource*
-
-The construction of an `execution_context` on a component implies affinity (where possible) to the given resource. This guarantees that all executors created from that `execution_context` can access the resources and the internal data structures requires to guarantee the placement of the processor.
-
-Only developers that care about resource placement need to care about obtaining executors and allocations from the correct `execution_context` object. Existing code for vectors and STL (including the Parallel STL interface) remains unaffected.
-
-If a particular policy or algorithm requires to access placement information, the resources associated with the passed executor can be retrieved via the link to the `execution_context`.
 
 ## Header `<execution>` synopsis
 
@@ -313,54 +288,37 @@ If a particular policy or algorithm requires to access placement information, th
     namespace experimental {
     namespace execution {
 
-    /* Execution resource */
+    /* Execution resource capable of executing std::thread */
 
-    class execution_resource {
+    class thread_execution_resource {
      public:
+      using iterator = /* implementation defined, dereferences to thread_execution_resource */ ;
 
-      execution_resource() = delete;
-      execution_resource(const execution_resource &);
-      execution_resource(execution_resource &&);
-      execution_resource &operator=(const execution_resource &);
-      execution_resource &operator=(execution_resource &&);
-      ~execution_resource();
+      ~thread_execution_resource();
+      thread_execution_resource() = delete;
+      thread_execution_resource(const thread_execution_resource &) = delete ;
+      thread_execution_resource(thread_execution_resource &&) = delete ;
+      thread_execution_resource &operator=(const thread_execution_resource &) = delete ;
+      thread_execution_resource &operator=(thread_execution_resource &&) = delete ;
 
       size_t concurrency() const noexcept;
 
-      std::vector<resource> resources() const noexcept;
+      iterator begin() const noexcept ;
+      iterator end() const noexcept ;
 
       const execution_resource member_of() const noexcept;
 
+      struct memory_resources_t {
+        using iterator = /* implementation defined, dereference to std::pmr::memory_resource */
+	iterator begin() const noexcept ;
+	iterator end() const noexcept ;
+      };
+
+      memory_resources_t const & memory_resources() const noexcept ;
+
       std::string name() const noexcept;
 
-      bool can_place_memory() const noexcept;
-      bool can_place_agent() const noexcept;
-
-    };
-
-    /* Execution context */
-
-    class execution_context {
-     public:
-
-      using executor_type = see-below;
-
-      using pmr_memory_resource_type = see-below;
-
-      using allocator_type = see-below;
-
-      execution_context(const execution_resource &) noexcept;
-
-      ~execution_context();
-
-      const execution_resource &resource() const noexcept;
-
-      executor_type executor() const;
-
-      pmr_memory_resource_type &memory_resource() const;
-
-      allocator_type allocator() const;
-
+      bool can_bind() const noexcept;
     };
 
     /* Affinity query */
@@ -373,9 +331,9 @@ If a particular policy or algorithm requires to access placement information, th
      public:
 
       using native_affinity_type = see-below;
-      using error_type = see-below
+      using error_type = see-below;
 
-      affinity_query(execution_resource &&, execution_resource &&) noexcept;
+      affinity_query(execution_resource & const , std::pmr::memory_resource & const ) noexcept;
 
       ~affinity_query();
 
@@ -387,7 +345,6 @@ If a particular policy or algorithm requires to access placement information, th
       friend expected<size_t, error_type> operator>(const affinity_query&, const affinity_query&);
       friend expected<size_t, error_type> operator<=(const affinity_query&, const affinity_query&);
       friend expected<size_t, error_type> operator>=(const affinity_query&, const affinity_query&);
-
     };
 
     }  // execution
@@ -395,7 +352,7 @@ If a particular policy or algorithm requires to access placement information, th
     /* This system */
 
     namespace this_system {
-      std::vector<execution_resource> resources() noexcept;
+      thread_execution_resource() noexcept ;
     }
 
     /* This thread */
@@ -409,108 +366,36 @@ If a particular policy or algorithm requires to access placement information, th
 
 *Listing 6: Header synopsis*
 
-## Class `execution_resource`
+## Class `thread_execution_resource`
 
-The `execution_resource` class provides an abstraction over a system's hardware, that can allocate memory and/or execute lightweight execution agents. An `execution_resource` can represent further `execution_resource`s. We say that these `execution_resource`s are *members of* this `execution_resource`.
-
-> [*Note:* The `execution_resource` is required to be implemented such that the underlying software abstraction is initialized when the `execution_resource` is constructed, maintained through reference counting, and cleaned up on destruction of the final reference. *--end note*]
-
-### `execution_resource` constructors
-
-    execution_resource();
-
-> [*Note:* An implementation of `execution_resource` is permitted to provide non-public constructors to allow other objects to construct them. *--end note*]
-
-### `execution_resource` assignment
-
-    execution_resource(const execution_resource &);
-    execution_resource(execution_resource &&);
-    execution_resource &operator=(const execution_resource &);
-    execution_resource &operator=(execution_resource &&);
-
-### `execution_resource` destructor
-
-    ~execution_resource();
+The `thread_execution_resource` class provides an interface to a system's hardware 
+capable of executing `std::thread`s.
 
 ### `execution_resource` operations
 
     size_t concurrency() const noexcept;
 
-*Returns:* The total concurrency available to this resource. More specifically, the number of *threads of execution* collectively available to this `execution_resource` and any resources which are *members of*, recursively.
+*Returns:* The upper bound concurrency available to this resource; 
+*i.e.*, the number of execution agents that could possibly concurrently make forward progress.
+when execution on this execution resource.
 
-    std::vector<resource> resources() const noexcept;
+    iterator begin() const noexcept;
+    iterator end() const noexcept;
 
-*Returns:* All `execution_resource`s which are *members of* this resource.
+*Returns:* Range of member execution resources.
 
-    const execution_resource &member_of() const noexcept;
+    const thread_execution_resource &member_of() const noexcept;
 
-*Returns:* The `execution_resource` which this resource is a *member of*.
+*Returns:* The `thread_execution_resource` which this resource is a *member of*.
 
     std::string name() const noexcept;
 
 *Returns:* An implementation defined string.
 
-    bool can_place_memory() const noexcept;
+    bool can_bind() const noexcept;
 
-*Returns:* If this resource is capable of allocating memory with affinity, 'true'.
+*Returns:* True if this resource is capable of binding `std::thread`s.
 
-    bool can_place_agent() const noexcept;
-
-*Returns:* If this resource is capable of execute with affinity, 'true'.
-
-## Class `execution_context`
-
-The `execution_context` class provides an abstraction for managing a number of lightweight execution agents executing work on an `execution_resource` and any `execution_resource`s encapsulated by it. The `execution_resource` which an `execution_context` encapsulates is refered to as the *contained resource*.
-
-### `execution_context` types
-
-    using executor_type = see-below;
-
-*Requires:* `executor_type` is an implementation defined class which satifies the general executor requires, as specified by P0443r5.
-
-    using pmr_memory_resource_type = see-below;
-
-*Requires:* `pmr_memory_resource_type` is an implementation defined class which inherits from `std::pmr::memory_resource`.
-
-    using allocator_type = see-below;
-
-*Requires:* `allocator_type` is an implementation defined allocator class.
-
-### `execution_context` constructors
-
-    execution_context(const execution_resource &) noexcept;
-
-*Effects:* Constructs an `execution_context` with the provided resource as the *contained resource*.
-
-### `execution_context` destructor
-    
-    ~execution_context();
-
-*Effects:* May or may not block to wait any work being executed on the *contained resource*.
-
-### `execution_context` operators
-
-    const execution_resource &resource() const noexcept;
-
-*Returns:* A const-reference to the *contained resource*.
-
-    executor_type executor() noexcept;
-
-*Returns:* An executor of type `executor_type` capable of executing work with affinity to the *contained resource*.
-
-*Throws:* An exception `!this->resource().can_place_agents()`.
-
-    pmr::memory_resource &memory_resource() noexcept;
-
-*Returns:* A reference to a polymorphic memory resource of type `pmr_memory_resource_type` capable of allocating with affinity to the *contained resource*.
-
-*Throws:* If `!this->resource().can_place_memory()`.
-
-    allocator_type allocator() const;
-
-*Returns:* An allocator of type `allocator_type` capable of allocating with affinity to the *contained resource*.
-
-*Throws:* If `!this->resource().can_place_memory()`.
 
 ## Class template `affinity_query`
 
@@ -528,7 +413,7 @@ The `affinity_query` class template provides an abstraction for a relative affin
 
 ### `affinity_query` constructors
 
-    affinity_query(const execution_resource &, const execution_resource &) noexcept;
+    affinity_query(const execution_resource &, const std::pmr::memory_resource &) noexcept;
 
 ### `affinity_query` destructor
 
@@ -559,35 +444,32 @@ The `affinity_query` class template provides an abstraction for a relative affin
 
 ## Free functions
 
-### `this_system::get_resources`
+The free function `this_system::execution_resource()` is provided for retrieving the `execution_resource`s which encapsulate the hardware platforms available within the system, these are refered to as the *system level resources*.
 
-The free function `this_system::get_resources` is provided for retrieving the `execution_resource`s which encapsulate the hardware platforms available within the system. We refer to these resources as the *system level resources*.
+    thread_execution_resource this_system::execution_resource() noexcept ;
 
-	std::vector<execution_resource> resources() noexcept;
+*Returns:*  Execution resource encapsulating all resources on which the program is permitted to executed a `std::thread`.
 
-*Returns:* An `std::vector` containing all *system level resources*.
+### `this_thread::get_execution_resource`
 
-*Requires:* If `this_system::get_resources().size() > 0`, `this_system::get_resources()[0]` be the `execution_resource` use by `std::thread`. The value returned by `this_system::get_resources()` be the same at any point after the invocation of `main`.
+The free function `this_thread::get_execution_resource` is provided for retrieving the `thread_execution_resource` underlying the current thread of execution.
 
-> [*Note:* Returning a `std::vector` allows users to potentially manipulate the container of `execution_resource`s after it is returned. We may want to replace this at a later date with an alternative type which is more restrictive, such as a range or span. *--end note*]
+    std::experimental::execution::thread_execution_resource get_thread_resource() noexcept;
 
-### `this_thread::get_resource`
-
-The free function `this_thread::get_resource` is provided for retrieving the `execution_resource` underlying the current thread of execution.
-
-    std::experimental::execution::execution_resource get_resource() noexcept;
-
-*Returns:* The `execution_resource` underlying the current thread of execution.
+*Returns:* The `thread_execution_resource` underlying the current thread of execution.
 
 # Future Work
 
 ## Migrating data from memory allocated in one partition to another
 
-In some cases, it is better for good performance to bind a memory allocation to a memory region for the duration of a task's execution.  However, in other cases, it is better to be able to migrate data from one memory region to another. This is outside the scope of this paper, though we would like to investigate this in a future paper.
+In some cases for performance it is important to *bind* or *rebind* 
+allocated memory to a narrower scope than it was allocated.
+For example, memory allocated at the system level is bound to NUMA region 0
+and subsequently rebound to NUMA region 1.
 
 | Straw Poll |
 |------------|
-| Should the interface provide a way of migrating data between partitions? |
+| Should the interface provide a way of binding or rebinding data to partitions? |
 
 ## Defining memory placement algorithms or policies
 
@@ -609,11 +491,11 @@ We may wish to mirror the design of the executors proposal and have a generic qu
 
 ## Dynamic topology discovery
 
-The current proposal requires that all `execution_resource`s are initialized before `main` is called. This therefore does not permit an `execution_resource` to become available or go off-line at run time. We may wish to support this in the future, however this is outside of the scope of this paper at the moment.
+The current proposal requires that all `thread_execution_resource`s are defined before `main` is called. This therefore does not permit a `thread_execution_resource` to become available or go off-line at run time. We may wish to support this in the future, however this is outside of the scope of this paper at the moment.
 
 | Straw Poll |
 |------------|
-| Should we support dynamically adding and removing `execution_resource`s at run time? |
+| Should we support dynamically adding and removing `thread_execution_resource`s at run time? |
 
 # Acknowledgements
 


### PR DESCRIPTION
Split execution and memory resources within topology.
Make execution resources iterable.
Reduce scope by removing specific execution context, which was not needed for affinity exploration.
Tied current naming and discussion to execution resource capable of executing `std:;thread`.