### PR TITLE
CP013: Introduce new properties and examples to affinity paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Each proposal in the table below will be tagged with one of the following states
 | CP009 | [Async Work Group Copy & Prefetch Builtins](async-work-group-copy/index.md) | SYCL 1.2.1 | 07 August 2017 | 07 August 2017 | _Accepted with changes_ |
 | CP011 | [Mem Fence Builtins](mem-fence/index.md) | SYCL 1.2.1 | 11 August 2017 | 9 September 2017 | _Accepted_ |
 | CP012 | [Data Movement in C++](data-movement/index.md) | ISO C++ SG1, SG14 | 30 May 2017 | 28 August 2017 | _Work in Progress_ |
-| CP013 | [Executor properties for affinity-based execution <br> System topology discovery for heterogeneous & distributed computing](affinity/index.md) | ISO C++ SG1, SG14, LEWG | 15 November 2017 | 12 January 2019 | _Work in Progress_ |
+| CP013 | [P1436: Executor properties for affinity-based execution](affinity/index.md) | ISO C++ SG1, SG14, LEWG | 15 November 2017 | 21 January 2019 | _Work in Progress_ |
 | CP014 | [Shared Virtual Memory](svm/index.md) | SYCL 2.2 | 22 January 2018 | 22 January 2018 | _Work in Progress_ |
 | CP015 | [Specialization Constant](spec-constant/index.md) | SYCL 1.2.1 extension / SYCL 2.2 | 24 April 2018 | 24 April 2018 | _Work in Progress_ |
 | CP019 | [On-chip Memory Allocation](onchip-memory/index.md) | SYCL 1.2.1 extension / SYCL 2.2 | 03 December 2018 | 03 December 2018 | _Work in Progress_ |

--- a/affinity/cpp-20/d1436r0.md
+++ b/affinity/cpp-20/d1436r0.md
@@ -22,6 +22,7 @@
 * Introduce new executor property `concurrency_t`.
 * Introduce new executor property `execution_locality_intersection_t`.
 * Introduce new executor property `memory_locality_intersection_t`.
+* Update direction for future work.
 
 ### P0796r3 (SAN 2018)
 
@@ -58,11 +59,9 @@
 
 # Abstract
 
-This paper is the result of a request from SG1 at the 2018 San Diego meeting to split P0796: Supporting Heterogeneous & Distributed Computing Through Affinity [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the high-level interface: a series of properties for querying affinity relationships and requesting affinity on work being executed. [[36]][pXXXX] focusses on the low-level interface: a mechanism for discovering the topology and affinity properties of a given system.
+This paper is the result of a request from SG1 at the 2018 San Diego meeting to split P0796: Supporting Heterogeneous & Distributed Computing Through Affinity [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the high-level interface: a series of properties for querying affinity relationships and requesting affinity on work being executed. [[36]][p1437] focusses on the low-level interface: a mechanism for discovering the topology and affinity properties of a given system.
 
-This paper provides an initial meta-framework for the drives toward an execution and memory affinity model for C\+\+.  It accounts for feedback from the Toronto 2017 SG1 meeting on Data Movement in C\+\+ [[1]][p0687r0] that we should define affinity for C\+\+ first, before considering inaccessible memory as a solution to the separate memory problem towards supporting heterogeneous and distributed computing.
-
-This paper proposes a series of executor properties which can be used to apply affinity requirements to bulk execution functions.
+The aim of this paper is to provide a number of executor properties that if supported allow the user of an executor to query and manipulate the binding of *execution agents* and the underlying *execution resources* of the *threads of execution* they are run on.
 
 
 # Motivation
@@ -79,7 +78,13 @@ The affinity problem is especially challenging for applications whose behavior c
 
 Frequently, data are initialized at the beginning of the program by the initial thread and are used by multiple threads. While some OSes automatically migrate threads or data for better affinity, migration may have high overhead. In an optimal case, the OS may automatically detect which thread access which data most frequently, or it may replicate data which are read by multiple threads, or migrate data which are modified and used by threads residing on remote locality groups. However, the OS often does a reasonable job, if the machine is not overloaded, if the application carefully uses first-touch allocation, and if the program does not change its behavior with respect to locality.
 
-Consider a code example *(Listing 1)* that uses the C\+\+17 parallel STL algorithm `for_each` to modify the entries of an `std::vector` `data`.  The example applies a loop body in a lambda to each entry of the `std::vector` `data`, using an execution policy that distributes work in parallel across multiple CPU cores. We might expect this to be fast, but since `std::vector` containers are initialized automatically and automatically allocated on the master thread's memory, we find that it is actually quite slow even when we have more than one thread.
+The affinity interface we propose should help computers achieve a much higher fraction of peak memory bandwidth when using parallel algorithms. In the future, we plan to extend this to heterogeneous and distributed computing. This follows the lead of OpenMP [[2]][design-of-openmp], which has plans to integrate its affinity model with its heterogeneous model [3]. (One of the authors of this document participated in the design of OpenMP's affinity model.)
+
+## Motivational examples
+
+To identify the requirements for supporting affinity we have looked at a number of use cases where affinity between memory locality and execution can provide better performance.
+
+Consider the following code example *(Listing 1)* where the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However the memory is allocated by the `std::vector` default allocator immediately during the construction of `data` on memory local to the calling *thread of execution*. This means the memory allocated for `data` has bad locality to the NUMA regions on the system, therefore as is would incur higher latency when accessed. In this example, this is avoided by migrating `data` to have better affinity with the NUMA regions on the system using an *executor* with the `bulk_execution_affinity.scatter` property applied, before it is accessed by the `for_each`. Note that a mechanism for miration is not yet specified in this paper so this is example currently uses a vendor API; `vendor_api::migrate`, though the intention is that this will be replaced in a future revision.
 
 ```cpp
 // NUMA executor representing N NUMA regions.
@@ -90,13 +95,13 @@ numa_executor exec;
 std::vector<float> data(N * SIZE);
 
 // Require the NUMA executor to bind its migration of memory to the underlying
-// memory resources in a scatter pattern.s
+// memory resources in a scatter pattern.
 auto affinityExec = std::execution::require(exec,
   bulk_execution_affinity.scatter);
 
 // Migrate the memory allocated for the vector across the NUMA regions in a
 // scatter pattern.
-std::execution::migrate(std::begin(data), std::end(data), affinityExec);
+vendor_api::migrate(std::begin(data), std::end(data), affinityExec);
 
 // Placement of data is local to NUMA region 0, so data for execution on other
 // NUMA nodes must is migrated when accessed.
@@ -104,6 +109,8 @@ std::for_each(std::execution::par.on(affinityExec), std::begin(data),
   std::end(data), [=](float &value) { do_something(value): });
 ```
 *Listing 1: Migrating previously allocated memory.*
+
+Now consider a similar code example *(Listing 2)* where again the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However instead of migrating `data` to have affinity with the NUMA regions, `data` is allocated within a bulk execution by an *executor* with the `bulk_execution_affinity.scatter` property applied so that `data` is allocated with affinity. Then when the `for_each` is called with the same executor, `data` maintains its affinity with the NUMA regions.
 
 ```cpp
 // NUMA executor representing N NUMA regions.
@@ -131,11 +138,20 @@ std::for_each(std::execution::par.on(affinityExec), std::begin(data),
 ```
 *Listing 2: Aligning memory and process affinity.*
 
-The affinity interface we propose should help computers achieve a much higher fraction of peak memory bandwidth when using parallel algorithms. In the future, we plan to extend this to heterogeneous and distributed computing. This follows the lead of OpenMP [[2]][design-of-openmp], which has plans to integrate its affinity model with its heterogeneous model [3]. (One of the authors of this document participated in the design of OpenMP's affinity model.)
 
-# Background Research: State of the Art
+# Background Research
 
-The problem of effectively partitioning a system’s topology has existed for some time, and there are a range of third-party libraries and standards which provide APIs to solve the problem. In order to standardize this process for C\+\+, we must carefully look at all of these approaches and identify which we wish to adopt. Below is a list of the libraries and standards from which this proposal will draw:
+In this paper we describe the problem space of affinity for C\+\+, the various challenges which need to be addressed in defining a partitioning and affinity interface for C\+\+, and some suggested solutions. These include:
+
+* How to migrate memory work and memory allocations between execution resources.
+* How to query affinity properties between different *executors*.
+* How to bind execution and allocation particular *executors*.
+
+Wherever possible, we also evaluate how an affinity-based solution could be scaled to support both distributed and heterogeneous systems.
+
+## State of the art
+
+The *affinity problem* existed for some time, and there are a number of third-party libraries and standards which provide APIs to solve the problem. In order to standardize this process for C\+\+, we must carefully look at all of these approaches and identify which we wish ideas are suitable for adoption into C\+\+. Below is a list of the libraries and standards from which this proposal will draw:
 
 * Portable Hardware Locality [[4]][hwloc]
 * SYCL 1.2 [[5]][sycl-1-2-1]
@@ -155,53 +171,19 @@ The problem of effectively partitioning a system’s topology has existed for so
 * HPX [[19]][hpx]
 * MADNESS [[20]][madness][[32]][madness-journal]
 
-Libraries such as the [Portable Hardware Locality (hwloc) library][hwloc] provide a low level of hardware abstraction, and offer a solution for the portability problem by supporting many platforms and operating systems. This and similar approaches use a tree structure to represent details of CPUs and the memory system. However, even some current systems cannot be represented correctly by a tree, if the number of hops between two sockets varies between socket pairs [[2]][design-of-openmp].
+Libraries such as the [Portable Hardware Locality (hwloc) library][hwloc] provide a low-level of hardware abstraction, and offer a solution for the portability problem by supporting many platforms and operating systems. This and similar approaches use a tree structure to represent details of CPUs and the memory system. However, even some current systems cannot be represented correctly by a tree, if the number of hops between two sockets varies between socket pairs [[2]][design-of-openmp].
 
 Some systems give additional user control through explicit binding of threads to processors through environment variables consumed by various compilers, system commands, or system calls.  Examples of system commands include Linux's `taskset` and `numactl`, and Windows' `start /affinity`.  System call examples include Solaris' `pbind()`, Linux's `sched_setaffinity()`, and Windows' `SetThreadAffinityMask()`.
 
-## Problem Space (TODO)
+## Relative affinity of execution resources
 
-In this paper we describe the problem space of affinity for C\+\+, the various challenges which need to be addressed in defining a partitioning and affinity interface for C\+\+, and some suggested solutions.  These include:
+In order to make decisions about where to place execution or allocate memory in a given *system’s resource topology*, it is important to understand the concept of affinity between different *execution resources*. This is usually expressed in terms of latency between two resources. Distance does not need to be symmetric in all architectures. The relative position of two components in a system's topology does not necessarily indicate their affinity. For example, two cores from two different CPU sockets may have the same latency to access the same NUMA memory node.
 
-* How to represent, identify and navigate the topology of execution resources available within a heterogeneous or distributed system.
-* How to query and measure the relative affinity between different execution resources within a system.
-* How to bind execution and allocation particular execution resource(s).
-* What kind of and level of interface(s) should be provided by C\+\+ for affinity.
+This can be scaled to heterogeneous and distributed systems, as the relative affinity between components can apply to discrete heterogeneous and distributed systems as well.
 
-Wherever possible, we also evaluate how an affinity-based solution could be scaled to support both distributed and heterogeneous systems. We also have addressed some aspects of dynamic topology discovery.
+## Inaccessible memory
 
-There are also some additional challenges which we have been investigating but are not yet ready to be included in this paper, and which will be presented in a future paper:
-
-* How to migrate memory work and memory allocations between execution resources.
-* More general cases of dynamic topology discovery.
-* Fault tolerance, as it relates to dynamic topology.
-
-### Resource lifetime
-
-The initial solution may only target systems with a single addressable memory region. It may thus exclude devices like discrete GPUs. However, in order to maintain a unified interface going forward, the initial solution should consider these devices and be able to scale to support them in the future. In particular, in order to support heterogeneous systems, the abstraction must let the interface query the *resource topology* of the *system* in order to perform device discovery.
-
-The *resource* objects returned from the *topology discovery interface* are opaque, implementation-defined objects. They would not perform any scheduling or execution functionality which would be expected from an *execution context*, and they would not store any state related to an execution. Instead, they would simply act as an identifier to a particular partition of the *resource topology*. This means that the lifetime of a *resource* retrieved from an *execution context* must not be tied to the lifetime of that *execution context*.
-
-The lifetime of a *resource* instance refers to both validity and uniqueness. First, if a *resource* instance exists, does it point to a valid underlying hardware or software resource? That is, could an instance's validity ever change at run time? Second, could a *resource* instance ever point to a different (but still valid) underlying resource? It suffices for now to define "point to a valid underlying resource" informally. We will elaborate this idea later in this proposal.
-
-Creation of a *context* expresses intent to use the *resource*, not just to view it as part of the *resource topology*. Thus, if a *resource* could ever cease to point to a valid underlying resource, then users must not be allowed to create a *context* from the resource instance, or launch executions with that context. *Context* construction, and use of an *executor* with that *context* to launch an execution, both assert validity of the *context*'s *resource*.
-
-If a *resource* is valid, then it must always point to the same underlying thing. For example, a *resource* cannot first point to one CPU core, and then suddenly point to a different CPU core. *Contexts* can thus rely on properties like binding of operating system threads to CPU cores. However, the "thing" to which a *resource* points may be a dynamic, possibly software-managed pool of hardware. Here are three examples of this phenomenon:
-
-   1. The "hardware" may actually be a virtual machine (VM). At any point, the VM may pause, migrate to different physical hardware, and resume. If the VM presents the same virtual hardware before and after the migration, then the *resources* that an application running on the VM sees should not change.
-   2. The OS may maintain a pool of a varying number of CPU cores as a shared resource among different user-level processes. When a process stops using the resource, the OS may reclaim cores. It may make sense to present this pool as an *execution resource*.
-   3. A low-level device driver on a laptop may switch between a "discrete" GPU and an "integrated" GPU, depending on utilization and power constraints. If the two GPUs have the same instruction set and can access the same memory, it may make sense to present them as a "virtualized" single *execution resource*.
-
-In summary, a *resource* either identifies a thing uniquely, or harmlessly points to nothing. The section that follows will justify and explain this.
-
-### Querying the relative affinity of partitions
-
-In order to make decisions about where to place execution or allocate memory in a given *system’s resource topology*, it is important to understand the concept of affinity between different *execution resources*. This is usually expressed in terms of latency between two resources. Distance does not need to be symmetric in all architectures.
-
-The relative position of two components in the topology does not necessarily indicate their affinity. For example, two cores from two different CPU sockets may have the same latency to access the same NUMA memory node.
-
-This feature could be easily scaled to heterogeneous and distributed systems, as the relative affinity between components can apply to discrete heterogeneous and distributed systems as well.
-
+The initial solution proposed by this paper may only target systems with a single addressable memory region. It may thus exclude devices like discrete GPUs. However, in order to maintain a unified interface going forward, the initial solution should consider these devices and be able to scale to support them in the future.
 
 # Proposal
 
@@ -211,7 +193,21 @@ In this paper we propose an interface for discovering the execution resources wi
 
 A series of executor properties describe desired behavior when using parallel algorithms or libraries. These properties provide a low granularity and is aimed at users who may have little or no knowledge of the system architecture.
 
+## Execution resources
+
+*Execution resources* represent an abstraction of a hardware or software layer that guarantees a particular set of affinity properties, where the level of abstraction is implementation-defined. An implementation is permitted to migrate any underlying resources providing it guarantees the affinity properties remain consistent. This allows freedom for the implementor but also consistency for users.
+
+If an *execution resource* is valid, then it must always point to the same underlying thing. For example, a *resource* cannot first point to one CPU core, and then suddenly point to a different CPU core. An *execution context* can thus rely on properties like binding of operating system threads to CPU cores. However, the "thing" to which an *execution resource* points may be a dynamic, possibly a software-managed pool of hardware. Here are three examples of this phenomenon:
+
+   1. The "hardware" may actually be a virtual machine (VM). At any point, the VM may pause, migrate to different physical hardware, and resume. If the VM presents the same virtual hardware before and after the migration, then the *resources* that an application running on the VM sees should not change.
+   2. The OS may maintain a pool of a varying number of CPU cores as a shared resource among different user-level processes. When a process stops using the resource, the OS may reclaim cores. It may make sense to present this pool as an *execution resource*.
+   3. A low-level device driver on a laptop may switch between a "discrete" GPU and an "integrated" GPU, depending on utilization and power constraints. If the two GPUs have the same instruction set and can access the same memory, it may make sense to present them as a "virtualized" single *execution resource*.
+
+In summary, an *execution resource* either identifies a thing uniquely, or harmlessly points to nothing.
+
 ## Header `<execution>` synopsis
+
+Below *(Listing 3)* is a proposed extension to the `<execution>` header.
 
 ```cpp
 namespace std {
@@ -234,7 +230,7 @@ constexpr concurrency_t concurrency;
 
 struct execution_locality_intersection_t;
 
-constexpr execution_locality_intersection_t execution_locality_intersection;
+constexpr execution_locality_intersection_t<DestExecutor>;
 
 // Memory locality intersection property
 
@@ -246,7 +242,7 @@ constexpr memory_locality_intersection_t memory_locality_intersection;
 }  // experimental
 }  // std
 ```
-*Listing 7: Header synopsis*
+*Listing 3: Header synopsis*
 
 ## Bulk execution affinity properties
 
@@ -254,11 +250,11 @@ We propose an executor property group called `bulk_execution_affinity` which con
 
 ### Example
 
-Below is an example of executing a parallel task over 8 threads using `bulk_execute`, with the affinity binding `bulk_execution_affinity.scatter`.
+Below is an example *(Listing 4)* of executing a parallel task over 8 threads using `bulk_execute`, with the affinity binding `bulk_execution_affinity.scatter`.
 
 ```cpp
 {
-  auto exec = executionContext.executor();
+  executor exec;
 
   auto affExec = execution::require(exec, execution::bulk,
     execution::bulk_execution_affinity.scatter);
@@ -268,7 +264,7 @@ Below is an example of executing a parallel task over 8 threads using `bulk_exec
   }, 8, sharedFactory);
 }
 ```
-*Listing 3: Example of using the bulk_execution_affinity property*
+*Listing 4: Example of using the bulk_execution_affinity property*
 
 ### Proposed Wording
 
@@ -299,13 +295,20 @@ We propose a query-only executor property called `concurrency_t` which returns t
 
 ### Example
 
+Below is an example *(Listing 5)* of querying an executor for the maximum concurrency it can provide via `concurrency`.
+
 ```cpp
-TODO
+{
+  executor exec;
+
+  auto maxConcurrency = execution::query(exec, execution::concurrency);
+}
 ```
+*Listing 5: Example of using the concurrency property*
 
 ## Proposed Wording
 
-The `concurrency_t` property is a query-only property as defined in P0443 [[22]][p0443]. 
+The `concurrency_t` property *(Listing 6)* is a query-only property as defined in P0443 [[22]][p0443]. 
 
 ```cpp
 struct concurrency_t
@@ -320,6 +323,7 @@ struct concurrency_t
       = Executor::query(concurrency_t());
 };
 ```
+*Listing 6: Proposed specification for concurrency_t*
 
 The `concurrency_t` property can be used only with `query`, which returns the maximum potential concurrency available to the executor. If the value is not well defined or not computable, `0` is returned.
 
@@ -333,30 +337,40 @@ We propose a query-only executor property called `execution_locality_intersectio
 
 ### Example
 
+Below is an example *(Listing 7)* of querying whether two *executors* have overlapping maximum concurrency using `execution_locality_intersection`.
+
 ```cpp
-TODO
+{
+  executor_a execA;
+  executor_b execB;
+
+  auto concurrencyOverlap = execution::query(execA,
+    execution::execution_locality_intersection(execB));
+}
 ```
+*Listing 7: Example of using the concurrency property*
 
 ## Proposed Wording
 
-The `execution_locality_intersection_t` property is a query-only property as defined in P0443 [[22]][p0443]. 
+The `execution_locality_intersection_t` property *(Listing 8)* is a query-only property as defined in P0443 [[22]][p0443]. 
 
 ```cpp
-template <class DestExecutor>
 struct execution_locality_intersection_t
 {
-  constexpr execution_locality_intersection_t(const DestExecutor &);
-
   static constexpr bool is_requirable = false;
   static constexpr bool is_preferable = false;
 
   using polymorphic_query_result_type = size_t;
 
-  template<class Executor>
+  template<class Executor, class DestExecutor>
     static constexpr decltype(auto) static_query_v
-      = Executor::query(execution_locality_intersection_t(DestExecutor{}));
+      = Executor::query(execution_locality_intersection_t{}(DestExecutor{})));
+
+  template <class DestExecutor>
+  size_t operator()(DestExecutor &&d);
 };
 ```
+*Listing 8: Proposed specification for execution_locality_intersection_t*
 
 The `execution_locality_intersection_t` property can be used only with `query`, which returns the maximum potential concurrency available to both *executors*. If the value is not well defined or not computable, `0` is returned.
 
@@ -366,34 +380,46 @@ The value returned from `execution::query(e1, execution_locality_intersection_t(
 
 ## Memory locality intersection property
 
-We propose a query-only executor property called `execution_locality_intersection_t` which specifies whether two *executors* share a common address space.
+We propose a query-only executor property called `execution_locality_intersection_t` which specifies whether two *executors* share a common memory locality, such that memory allocated by those *executors* both have similar affinity.
+
+This is useful for determining whether memory local to one *executor* would require migration in order to be local to another *executor*.
 
 ### Example
 
+Below is an example *(Listing 9)* of querying whether two *executors* have common memory locality `execution_locality_intersection`.
+
 ```cpp
-TODO
+{
+  executor_a execA;
+  executor_b execB;
+
+  auto concurrencyOverlap = execution::query(execA,
+    execution::execution_locality_intersection(execB));
+}
 ```
+*Listing 9: Example of using the concurrency property*
 
 ## Proposed Wording
 
-The `memory_locality_intersection_t` property is a query-only property as defined in P0443 [[22]][p0443]. 
+The `memory_locality_intersection_t` property *(Listing 10)* is a query-only property as defined in P0443 [[22]][p0443]. 
 
 ```cpp
-template <class DestExecutor>
 struct memory_locality_intersection_t
 {
-  constexpr memory_locality_intersection_t(const DestExecutor &);
-
   static constexpr bool is_requirable = false;
   static constexpr bool is_preferable = false;
 
   using polymorphic_query_result_type = bool;
 
-  template<class Executor>
+  template<class Executor, class DestExecutor>
     static constexpr decltype(auto) static_query_v
-      = Executor::query(memory_locality_intersection_t(DestExecutor{}));
+      = Executor::query(memory_locality_intersection_t{}(DestExecutor{})));
+
+  template <class DestExecutor>
+  bool operator()(DestExecutor &&d);
 };
 ```
+*Listing 10: Proposed specification for memory_locality_intersection_t*
 
 The `memory_locality_intersection_t` property can be used only with `query`, which returns `true` if both *executors* share a common address space, and `false` otherwise. If the value is not well defined or not computable, `false` is returned.
 
@@ -402,23 +428,23 @@ The value returned from `execution::query(e1, memory_locality_intersection_t(e2)
 
 # Future Work
 
-## Who should have control over bulk execution affinity?
+There are a number of additional features which we are considering for inclusion in this paper but are not ready yet.
 
-This paper currently proposes the `bulk_execution_affinity_t` properties and its nested properties for allowing an *executor* to make guarantees as to how *execution agents* are bound to the underlying *execution resources*. However providing control at this level may lead to *execution agents* being bound to *execution resources* within a critical path. A possible solution to this is to allow the *execution context* to be configured with `bulk_execution_affinity_t` nested properties, either instead of the *executor* property or in addition. This would allow the binding of *threads of execution* to be performed at the time of the *execution context* creation.
+## Migrating data
 
-| Straw Poll |
-|------------|
-| Should the *execution context* be able to manage the binding of all *threads of execution* which it manages using the `bulk_execution_affinity_t` nested properties? |
-| Should the *executor* be able to manage the binding of all *execution agents* which it manages using the `bulk_execution_affinity_t` nested properties? |
-| Should both the *execution context* and the *executor* be able to manage the binding of *threads of execution* and subsequently *execution agents* using the `bulk_execution_affinity_t` nested properties? |
+This paper currently provides a mechanism for detecting whether two *executors* share a common memory locality. However it does not provide a way to invoke migration of data allocated local to one *executor* into the locality of another *executor*.
 
-## Migrating data from memory allocated in one partition to another
+We envision that this mechanic could be facilitated by a customization point on two *executors* and perhaps a `spann` or `mdspan` accessor.
 
-With the ability to place memory with affinity comes the ability to define algorithms or memory policies which describe at a higher level how memory is distributed across large systems. Some examples of these are pinned, first touch, and scatter. This is outside the scope of this paper, though we would like to investigate this in a future paper.
+## Supporting different affinity domains
 
-| Straw Poll |
-|------------|
-| Should the interface provide a way of migrating data between partitions? |
+This paper currently assumes a NUMA-like system, however there are many other kinds of systems with many different architectures with different kinds of processors, memory and connections between them.
+
+In order to accurately take advantage of the range of systems available now and in the future we will need some way to parameterized or enumerate the different affinity domains which an executor can structure around.
+
+Furthermore in order to have control over those affinity domains we need a way in which to mask out the components of that domain that we wish to work with.
+
+However whichever option we opt for, it must be in such a way as to allow further additions as new system architectures become available.
 
 
 # Acknowledgments
@@ -533,5 +559,5 @@ http://wg21.link/p0443
 [p0796]: http://wg21.link/p0796
 [[35]][p0796] Supporting Heterogeneous & Distributed Computing Through Affinity
 
-[pXXXX]: http://wg21.link/pXXXX
-[[36]][pXXXX] ######
+[pXXXX]: http://wg21.link/p1437
+[[36]][p1437] System topology discovery for heterogeneous & distributed computing

--- a/affinity/cpp-20/d1436r0.md
+++ b/affinity/cpp-20/d1436r0.md
@@ -114,7 +114,7 @@ numa_executor exec;
 std::vector<std::unique_ptr<float[SIZE]>> data{};
 data.reserve(N);
 
-// Require the NUMA executor to bind it's allocation of memory to the underlying
+// Require the NUMA executor to bind its allocation of memory to the underlying
 // memory resources in a scatter patter.
 auto affinityExec = std::execution::require(exec,
   bulk_execution_affinity.scatter);
@@ -125,7 +125,7 @@ affinityExec.bulk_execute([&](size_t id) {
   data[id] = std::make_unique<float>(); }, N, sharedFactory);
 
 // Execute a for_each using the same executor so that each unique_ptr in the
-// vector maintains it's locality.
+// vector maintains its locality.
 std::for_each(std::execution::par.on(affinityExec), std::begin(data),
   std::end(data), [=](float &value) { do_something(value): });
 ```

--- a/affinity/cpp-20/d1436r0.md
+++ b/affinity/cpp-20/d1436r0.md
@@ -1,4 +1,4 @@
-# D1436r0: Executor properties for affinity-based execution
+# P1436r0: Executor properties for affinity-based execution
 
 **Date: 2019-01-21**
 
@@ -6,7 +6,7 @@
 
 **Authors: Gordon Brown, Ruyman Reyes, Michael Wong, H. Carter Edwards, Thomas Rodgers, Mark Hoemmen**
 
-**Contributors: Patrice Roy, Carl Cook, Jeff Hammond, Hartmut Kaiser, Christian Trott, Paul Blinzer, Alex Voicu, Nat Goodspeed, Tony Tye, Paul Blinzer**
+**Contributors: Patrice Roy, Carl Cook, Jeff Hammond, Hartmut Kaiser, Christian Trott, Paul Blinzer, Alex Voicu, Nat Goodspeed, Tony Tye, Paul Blinzer, Chris Kohlhoff**
 
 **Emails: gordon@codeplay.com, ruyman@codeplay.com, michael@codeplay.com, hedwards@nvidia.com, rodgert@twrodgers.com, mhoemme@sandia.gov**
 
@@ -17,7 +17,7 @@
 
 ### P1436r0 (KON 2019)
 
-* Separation of high-level features from [[35]][p0796].
+* Separation of high-level features from P0796r3 [[35]][p0796].
 * Update motivational examples.
 * Introduce new executor property `concurrency_t`.
 * Introduce new executor property `execution_locality_intersection_t`.
@@ -59,7 +59,7 @@
 
 # Abstract
 
-This paper is the result of a request from SG1 at the 2018 San Diego meeting to split P0796: Supporting Heterogeneous & Distributed Computing Through Affinity [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the high-level interface: a series of properties for querying affinity relationships and requesting affinity on work being executed. [[36]][p1437] focusses on the low-level interface: a mechanism for discovering the topology and affinity properties of a given system.
+This paper is the result of a request from SG1 at the 2018 San Diego meeting to split P0796: Supporting Heterogeneous & Distributed Computing Through Affinity [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the high-level interface: a series of properties for querying affinity relationships and requesting affinity on work being executed. P0437 will focus on the low-level interface: a mechanism for discovering the topology and affinity properties of a given system, however this paper was not submitted in this mailing.
 
 The aim of this paper is to provide a number of executor properties that if supported allow the user of an executor to query and manipulate the binding of *execution agents* and the underlying *execution resources* of the *threads of execution* they are run on.
 
@@ -189,7 +189,7 @@ The initial solution proposed by this paper may only target systems with a singl
 
 ## Overview
 
-In this paper we propose an interface for discovering the execution resources within a system, querying the relative affinity metric between those execution resources, and then using those execution resources to allocate memory and execute work with affinity to the underlying hardware those execution resources represent. The interface described in this paper builds on the existing interface for executors and execution contexts defined in the executors proposal [[22]][p0443r7].
+In this paper we propose an interface for discovering the execution resources within a system, querying the relative affinity metric between those execution resources, and then using those execution resources to allocate memory and execute work with affinity to the underlying hardware those execution resources represent. The interface described in this paper builds on the existing interface for executors and execution contexts defined in the executors proposal [[22]][p0443].
 
 A series of executor properties describe desired behavior when using parallel algorithms or libraries. These properties provide a low granularity and is aimed at users who may have little or no knowledge of the system architecture.
 
@@ -516,8 +516,7 @@ Thanks to Christopher Di Bella, Toomas Remmelg, and Morris Hafner for their revi
 [lstopo]: https://www.open-mpi.org/projects/hwloc/lstopo/
 [[21]][lstopo] Portable Hardware Locality Istopo
 
-[p0443]:
-http://wg21.link/p0443
+[p0443]: http://wg21.link/p0443
 [[22]][p0443] A Unified Executors Proposal for C\+\+
 
 [p0737]: http://wg21.link/p0737
@@ -559,5 +558,5 @@ http://wg21.link/p0443
 [p0796]: http://wg21.link/p0796
 [[35]][p0796] Supporting Heterogeneous & Distributed Computing Through Affinity
 
-[pXXXX]: http://wg21.link/p1437
+[p1437]: http://wg21.link/p1437
 [[36]][p1437] System topology discovery for heterogeneous & distributed computing

--- a/affinity/cpp-20/d1436r0.md
+++ b/affinity/cpp-20/d1436r0.md
@@ -1,4 +1,4 @@
-# DXXXXr0: Executor properties for affinity-based execution
+# D1436r0: Executor properties for affinity-based execution
 
 **Date: 2019-01-12**
 
@@ -15,9 +15,13 @@
 
 # Changelog
 
-### PXXXXr0 (KON 2019)
+### P1436r0 (KON 2019)
 
 * Separation of high-level features from [[35]][p0796].
+* Update motivational examples.
+* Introduce new executor property `concurrency_t`.
+* Introduce new executor property `execution_locality_intersection_t`.
+* Introduce new executor property `memory_locality_intersection_t`.
 
 ### P0796r3 (SAN 2018)
 

--- a/affinity/cpp-20/d1436r0.md
+++ b/affinity/cpp-20/d1436r0.md
@@ -1,6 +1,6 @@
 # D1436r0: Executor properties for affinity-based execution
 
-**Date: 2019-01-12**
+**Date: 2019-01-21**
 
 **Audience: SG1, SG14, LEWG**
 
@@ -78,13 +78,13 @@ The affinity problem is especially challenging for applications whose behavior c
 
 Frequently, data are initialized at the beginning of the program by the initial thread and are used by multiple threads. While some OSes automatically migrate threads or data for better affinity, migration may have high overhead. In an optimal case, the OS may automatically detect which thread access which data most frequently, or it may replicate data which are read by multiple threads, or migrate data which are modified and used by threads residing on remote locality groups. However, the OS often does a reasonable job, if the machine is not overloaded, if the application carefully uses first-touch allocation, and if the program does not change its behavior with respect to locality.
 
-The affinity interface we propose should help computers achieve a much higher fraction of peak memory bandwidth when using parallel algorithms. In the future, we plan to extend this to heterogeneous and distributed computing. This follows the lead of OpenMP [[2]][design-of-openmp], which has plans to integrate its affinity model with its heterogeneous model [3]. (One of the authors of this document participated in the design of OpenMP's affinity model.)
+The affinity interface we propose should help computers achieve a much higher fraction of peak memory bandwidth when using parallel algorithms. In the future, we plan to extend this to heterogeneous and distributed computing. This follows the lead of OpenMP [[2]][design-of-openmp], which has plans to integrate its affinity model with its heterogeneity model [3]. (One of the authors of this document participated in the design of OpenMP's affinity model.)
 
 ## Motivational examples
 
 To identify the requirements for supporting affinity we have looked at a number of use cases where affinity between memory locality and execution can provide better performance.
 
-Consider the following code example *(Listing 1)* where the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However the memory is allocated by the `std::vector` default allocator immediately during the construction of `data` on memory local to the calling *thread of execution*. This means the memory allocated for `data` has bad locality to the NUMA regions on the system, therefore as is would incur higher latency when accessed. In this example, this is avoided by migrating `data` to have better affinity with the NUMA regions on the system using an *executor* with the `bulk_execution_affinity.scatter` property applied, before it is accessed by the `for_each`. Note that a mechanism for miration is not yet specified in this paper so this is example currently uses a vendor API; `vendor_api::migrate`, though the intention is that this will be replaced in a future revision.
+Consider the following code example *(Listing 1)* where the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However the memory is allocated by the `std::vector` default allocator immediately during the construction of `data` on memory local to the calling thread of execution. This means that the memory allocated for `data` may have poor locality to all of the NUMA regions on the system, other than the one in which the constructor executed. Therefore, accesses in the parallel `for_each` made by threads in other NUMA regions will incur high latency. In this example, this is avoided by migrating `data` to have better affinity with the NUMA regions on the system using an *executor* with the `bulk_execution_affinity.scatter` property applied, before it is accessed by the `for_each`. Note that a mechanism for migration is not yet specified in this paper, so this example currently uses an arbitrary vendor API, `vendor_api::migrate`. Our intention is that a future revision of this paper will specify a standard mechanism for migration
 
 ```cpp
 // NUMA executor representing N NUMA regions.
@@ -101,7 +101,7 @@ auto affinityExec = std::execution::require(exec,
 
 // Migrate the memory allocated for the vector across the NUMA regions in a
 // scatter pattern.
-vendor_api::migrate(std::begin(data), std::end(data), affinityExec);
+vendor_api::migrate(data, affinityExec);
 
 // Placement of data is local to NUMA region 0, so data for execution on other
 // NUMA nodes must is migrated when accessed.
@@ -110,7 +110,7 @@ std::for_each(std::execution::par.on(affinityExec), std::begin(data),
 ```
 *Listing 1: Migrating previously allocated memory.*
 
-Now consider a similar code example *(Listing 2)* where again the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However instead of migrating `data` to have affinity with the NUMA regions, `data` is allocated within a bulk execution by an *executor* with the `bulk_execution_affinity.scatter` property applied so that `data` is allocated with affinity. Then when the `for_each` is called with the same executor, `data` maintains its affinity with the NUMA regions.
+Now consider a similar code example *(Listing 2)* where again the C\+\+17 parallel STL algorithm `for_each` is used to modify the elements of a `std::vector` `data` on an *executor* that will execute on a NUMA system with a number of CPU cores. However, instead of migrating `data` to have affinity with the NUMA regions, `data` is allocated within a bulk execution by an *executor* with the `bulk_execution_affinity.scatter` property applied so that `data` is allocated with affinity. Then when the `for_each` is called with the same executor, `data` maintains its affinity with the NUMA regions.
 
 ```cpp
 // NUMA executor representing N NUMA regions.
@@ -151,7 +151,7 @@ Wherever possible, we also evaluate how an affinity-based solution could be scal
 
 ## State of the art
 
-The *affinity problem* existed for some time, and there are a number of third-party libraries and standards which provide APIs to solve the problem. In order to standardize this process for C\+\+, we must carefully look at all of these approaches and identify which we wish ideas are suitable for adoption into C\+\+. Below is a list of the libraries and standards from which this proposal will draw:
+The *affinity problem* existed for some time, and there are a number of third-party libraries and standards which provide APIs to solve the problem. In order to standardize this process for C\+\+, we must carefully look at all of these approaches and identify which ideas are suitable for adoption into C\+\+. Below is a list of the libraries and standards from which this proposal will draw:
 
 * Portable Hardware Locality [[4]][hwloc]
 * SYCL 1.2 [[5]][sycl-1-2-1]
@@ -183,7 +183,7 @@ This can be scaled to heterogeneous and distributed systems, as the relative aff
 
 ## Inaccessible memory
 
-The initial solution proposed by this paper may only target systems with a single addressable memory region. It may thus exclude devices like discrete GPUs. However, in order to maintain a unified interface going forward, the initial solution should consider these devices and be able to scale to support them in the future.
+The initial solution proposed by this paper may only target systems with a single addressable memory region. It may therefore exclude certain heterogeneous devices such as some discrete GPUs. However, in order to maintain a unified interface going forward, the initial solution should consider these devices and be able to scale to support them in the future.
 
 # Proposal
 
@@ -432,19 +432,19 @@ There are a number of additional features which we are considering for inclusion
 
 ## Migrating data
 
-This paper currently provides a mechanism for detecting whether two *executors* share a common memory locality. However it does not provide a way to invoke migration of data allocated local to one *executor* into the locality of another *executor*.
+This paper currently provides a mechanism for detecting whether two *executors* share a common memory locality. However, it does not provide a way to invoke migration of data allocated local to one *executor* into the locality of another *executor*.
 
-We envision that this mechanic could be facilitated by a customization point on two *executors* and perhaps a `spann` or `mdspan` accessor.
+We envision that this mechanic could be facilitated by a customization point on two *executors* and perhaps a `span` or `mdspan` accessor.
 
 ## Supporting different affinity domains
 
 This paper currently assumes a NUMA-like system, however there are many other kinds of systems with many different architectures with different kinds of processors, memory and connections between them.
 
-In order to accurately take advantage of the range of systems available now and in the future we will need some way to parameterized or enumerate the different affinity domains which an executor can structure around.
+In order to accurately take advantage of the range of systems available now and in the future we will need some way to parameterize or enumerate the different affinity domains which an executor can structure around.
 
-Furthermore in order to have control over those affinity domains we need a way in which to mask out the components of that domain that we wish to work with.
+Furthermore, in order to have control over those affinity domains we need a way in which to mask out the components of that domain that we wish to work with.
 
-However whichever option we opt for, it must be in such a way as to allow further additions as new system architectures become available.
+However, whichever option we opt for, it must be in such a way as to allow further additions as new system architectures become available.
 
 
 # Acknowledgments

--- a/affinity/cpp-20/d1437r0.md
+++ b/affinity/cpp-20/d1437r0.md
@@ -901,5 +901,5 @@ http://wg21.link/p0443
 [p0796]: http://wg21.link/p0796
 [[35]][p0796] Supporting Heterogeneous & Distributed Computing Through Affinity
 
-[pXXXX]: http://wg21.link/pXXXX
-[[36]][pXXXX] ######
+[pXXXX]: http://wg21.link/p1436
+[[36]][p1436] Executor properties for affinity-based execution

--- a/affinity/cpp-20/d1437r0.md
+++ b/affinity/cpp-20/d1437r0.md
@@ -1,4 +1,4 @@
-# DXXXXr0: System topology discovery for heterogeneous & distributed computing
+# D1437r0: System topology discovery for heterogeneous & distributed computing
 
 **Date: 2019-01-12**
 
@@ -15,7 +15,7 @@
 
 # Changelog
 
-### PXXXXr0 (KON 2019)
+### P1437r0 (KON 2019)
 
 * This paper is the result of a request from SG1 at the 2018 San Diego meeting to split [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the low-level interface; a mechanism for discovering the topology and affinity properties of a given system. [[36]][pXXXX] focusses on the high-level interface; a series of properties for querying affinity relationships and requesting affinity on work being executed.
 

--- a/affinity/index.md
+++ b/affinity/index.md
@@ -1,19 +1,21 @@
-# Supporting Heterogeneous & Distributed Computing Through Affinity
+# P1436: Executor properties for affinity-based execution
 
 |   |   |
 |---|---|
 | ID | CP013 |
-| Name | Executor properties for affinity-based execution <br> System topology discovery for heterogeneous & distributed computing |
-| Target | ISO C++ SG1 SG14 |
+| Name | Executor properties for affinity-based execution |
+| Target | ISO C++ SG1, SG14, LEWG |
 | Initial creation | 15 November 2017 |
-| Last update | 12 August 2018 |
-| Reply-to | Michael Wong <michael.wong@codeplay.com> |
+| Last update | 21 January 2019 |
+| Reply-to | Gordon Brown <gordon@codeplay.com> |
 | Original author | Gordon Brown <gordon@codeplay.com> |
-| Contributors | Ruyman Reyes <ruyman@codeplay.com>, Michael Wong <michael.wong@codeplay.com>, H. Carter Edwards <hcedwar@sandia.gov>, Thomas Rodgers <rodgert@twrodgers.com> |
+| Contributors | Ruyman Reyes <ruyman@codeplay.com>, Michael Wong <michael.wong@codeplay.com>, H. Carter Edwards <hcedwar@sandia.gov>, Thomas Rodgers <rodgert@twrodgers.com>, Mark Hoemmen <mhoemme@sandia.gov> |
 
 ## Overview
 
-This paper provides an initial meta-framework for the drives toward memory affinity for C++, given the direction from Toronto 2017 SG1 meeting that we should look towards defining affinity for C++ before looking at inaccessible memory as a solution to the separate memory problem towards supporting heterogeneous and distributed computing.
+This paper is the result of a request from SG1 at the 2018 San Diego meeting to split P0796: Supporting Heterogeneous & Distributed Computing Through Affinity [[35]][p0796] into two separate papers, one for the high-level interface and one for the low-level interface. This paper focusses on the high-level interface: a series of properties for querying affinity relationships and requesting affinity on work being executed. [[36]][p1437] focusses on the low-level interface: a mechanism for discovering the topology and affinity properties of a given system.
+
+The aim of this paper is to provide a number of executor properties that if supported allow the user of an executor to query and manipulate the binding of *execution agents* and the underlying *execution resources* of the *threads of execution* they are run on.
 
 ## Versions
 
@@ -23,7 +25,7 @@ This paper provides an initial meta-framework for the drives toward memory affin
 | [P0796r1][p0796r1] | _Published_ |
 | [D0796r2][p0796r2] | _Published_ |
 | [D0796r3][p0796r3] | _Published_ |
-| [DXXX1r0](cpp-20/dXXX1r0.md) <br> [DXXX2r0](cpp-20/dXXX2r0.md) | _Work In Progress_ |
+| [DXXX1r0](cpp-20/d1436r0.md) | _Work In Progress_ |
 
 [p0796r0]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0796r0.pdf
 [p0796r1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0796r1.pdf


### PR DESCRIPTION
**Changes**

* Replace current motivational example with two new examples: one
showing migration of a pre-allocated container to gain affinity, and one
showing using the bulk_execution_affinity property to bind allocation
and execution locality.
* Introduce the `concurrency_t property`, reflecting that which was
previously available via the `execution_context`.
* Introduce the `execution_locality_intersection_t` property which
returns the maximum concurrency common to two executors.
* Introduce the `memory_locality_intersection_t` property which returns
true if two executors have a common address space.
* Remove sections of background research not relative to high-level
interface.
* Add examples for each of the new properties.
* Update future work section to be more relative to the high-level
interface.
* Make some other minor editorial fixes.