### PR TITLE
Default constructed accessors

### DIFF
--- a/placeholder_accessors/index.md
+++ b/placeholder_accessors/index.md
@@ -224,7 +224,7 @@ A null accessor does not need to be registered with the command group,
 i.e. there is no need to call `require()` on it.
 It is allowed to pass a null accessor to a kernel,
 as long as it's not dereferenced inside the kernel,
-otherwise there an out-of-bounds access will occur,
+otherwise an out-of-bounds access will occur,
 likely leading to a segmentation fault or similar.
 If the null accessor has been bound to a buffer,
 it is no longer a null accessor,
@@ -236,7 +236,7 @@ by calling the member function `is_null`.
 
 |Member function      |Description                                              |
 |---------------------|---------------------------------------------------------|
-|bool is_null() const |Returns true if the accessor is associated with a buffer, false otherwise.|
+|bool is_null() const |Returns false if the accessor is associated with a buffer, true otherwise.|
 
 
 [1]: https://github.com/codeplaysoftware/sycl-blas "SYCL-BLAS"


### PR DESCRIPTION
This relates to https://github.com/codeplaysoftware/standards-proposals/pull/18.

It introduces a default constructed placeholder accessor, similar to that patch,
called a null accessor here.
Instead of proposing a `require(buf, acc)`,
the buffer can be "bound" to an accessor by creating a new placeholder accessor
that is already bound to a buffer.
It can then be used as a normal placeholder accessor.
If it's not bound, it can still be passed into a kernel,
but should not be dereferenced inside the kernel.

A new free function `make_placeholder_accessor` accessor is also proposed.