### PR TITLE
Update P1436 and P1795 after Belfast ISO C++ meeting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ from this registry in the future.
 | CP009 | [Async Work Group Copy & Prefetch Builtins](async-work-group-copy/index.md) | SYCL 1.2.1 | 07 August 2017 | 07 August 2017 | _Accepted with changes_ |
 | CP011 | [Mem Fence Builtins](mem-fence/index.md) | SYCL 1.2.1 | 11 August 2017 | 9 September 2017 | _Accepted_ |
 | CP012 | [Data Movement in C++](data-movement/index.md) | ISO C++ SG1, SG14 | 30 May 2017 | 28 August 2017 | _Work in Progress_ |
-| CP013 | [P1436 & P1795: Papers for affinity-based execution](affinity/index.md) | ISO C++ SG1, SG14, LEWG | 15 November 2017 | 17 June 2019 | _Published_ |
+| CP013 | [P1436 & P1795: Papers for affinity-based execution](affinity/index.md) | ISO C++ SG1, SG14, LEWG | 15 November 2017 | 23 November 2019 | _Published_ |
 | CP014 | [Shared Virtual Memory](svm/index.md) | SYCL 2.2 | 22 January 2018 | 22 January 2018 | _Work in Progress_ |
 | CP015 | [Specialization Constant](spec-constant/index.md) | SYCL 1.2.1 extension | 24 April 2018 | 24 April 2018 | _Work in Progress_ |
 | CP017 | [Host Access](host_access/index.md) | SYCL 1.2.1 vendor extension | 17 September 2018 | 13 December 2018 |  _Available since CE 1.0.3_ | 

--- a/affinity/cpp-23/d1436r3.md
+++ b/affinity/cpp-23/d1436r3.md
@@ -1,17 +1,18 @@
-# P1436r1: Executor properties for affinity-based execution
+# P1436r2: Executor properties for affinity-based execution
 
-**Date: 2019-03-31**
+**Date: 2019-11-23**
 
-**Audience: SG1, SG14, LEWG**
+**Audience: SG1, SG14**
 
 **Authors: Gordon Brown, Ruyman Reyes, Michael Wong, H. Carter Edwards, Thomas Rodgers, Mark Hoemmen**
-
-**Contributors: Patrice Roy, Carl Cook, Jeff Hammond, Hartmut Kaiser, Christian Trott, Paul Blinzer, Alex Voicu, Nat Goodspeed, Tony Tye, Paul Blinzer, Chris Kohlhoff**
 
 **Emails: gordon@codeplay.com, ruyman@codeplay.com, michael@codeplay.com, hedwards@nvidia.com, rodgert@twrodgers.com, mhoemme@sandia.gov**
 
 **Reply to: gordon@codeplay.com**
 
+# Acknowledgements
+
+This paper is the result of discussions from man contributors within the heterogeneous C\+\+ group, including Patrice Roy, Carl Cook, Jeff Hammond, Hartmut Kaiser, Christian Trott, Paul Blinzer, Alex Voicu, Nat Goodspeed, Tony Tye, Paul Blinzer and Chris Kohlhoff
 
 # Changelog
 
@@ -579,5 +580,5 @@ Thanks to Christopher Di Bella, Toomas Remmelg, and Morris Hafner for their revi
 [p0796]: http://wg21.link/p0796
 [[35]][p0796] Supporting Heterogeneous & Distributed Computing Through Affinity
 
-[p1437]: http://wg21.link/p1437
-[[36]][p1437] System topology discovery for heterogeneous & distributed computing
+[p1795]: http://wg21.link/p1795
+[[36]][p1795] System topology discovery for heterogeneous & distributed computing

--- a/affinity/cpp-23/d1795r2.md
+++ b/affinity/cpp-23/d1795r2.md
@@ -1,6 +1,6 @@
 # P1795r1: System topology discovery for heterogeneous & distributed computing
 
-**Date: 2019-10-07**
+**Date: 2019-11-23**
 
 **Audience: SG1, SG14**
 

--- a/affinity/index.md
+++ b/affinity/index.md
@@ -1,15 +1,14 @@
-# P1436 & P1795: Papers for affinity-based execution
+# P1436 & P1795: Papers for heterogeneous and distributed computing in C++
 
 |   |   |
 |---|---|
 | ID | CP013 |
-| Name | Executor properties for affinity-based execution <br> System topology discovery for heterogeneous & distributed computing |
-| Target | ISO C++ SG1, SG14, LEWG |
+| Name | P1436: Executor properties for affinity-based execution <br> P1795: System topology discovery for heterogeneous & distributed computing |
+| Target | ISO C++ SG1, SG14 |
 | Initial creation | 15 November 2017 |
-| Last update | 31 March 2019 |
+| Last update | 23 November 2019 |
 | Reply-to | Gordon Brown <gordon@codeplay.com> |
-| Original author | Gordon Brown <gordon@codeplay.com> |
-| Contributors | Ruyman Reyes <ruyman@codeplay.com>, Michael Wong <michael.wong@codeplay.com>, H. Carter Edwards <hcedwar@sandia.gov>, Thomas Rodgers <rodgert@twrodgers.com>, Mark Hoemmen <mhoemme@sandia.gov>, Jeff Hammond <jeff.science@gmail.com>, Tom Scogland <tscogland@llnl.gov> |
+| Authors | Gordon Brown <gordon@codeplay.com>, Ruyman Reyes <ruyman@codeplay.com>, Michael Wong <michael.wong@codeplay.com>, H. Carter Edwards <hcedwar@sandia.gov>, Thomas Rodgers <rodgert@twrodgers.com>, Mark Hoemmen <mhoemme@sandia.gov>, Jeff Hammond <jeff.science@gmail.com>, Tom Scogland <tscogland@llnl.gov> |
 
 ## Overview
 
@@ -32,14 +31,16 @@ This paper is the result of a request from SG1 at the 2018 San Diego meeting to 
 |---------|--------|
 | [P1436r0][p1436r0] | _Published_ |
 | [P1436r1][p1436r1] | _Published_ |
-| [D1436r2][d1436-latest] | _Work_in_progress_ |
+| [P1436r2][p1436r2] | _Published_ |
+| [D1436r3][d1436-latest] | _Work_in_progress_ |
 
 ### P1795: System topology discovery for heterogeneous & distributed computing
 
 | Version | Status |
 |---------|--------|
 | [P1795r0][p1795r0] | _Published_ |
-| [D1437r1][d1795-latest] | _Work_in_progress_ |
+| [P1795r1][p1795r1] | _Published_ |
+| [D1437r2][d1795-latest] | _Work_in_progress_ |
 
 [p0796]: https://wg21.link/p0796
 [p1436]: https://wg21.link/p1436
@@ -51,7 +52,9 @@ This paper is the result of a request from SG1 at the 2018 San Diego meeting to 
 
 [p1436r0]: https://wg21.link/p1436r0
 [p1436r1]: https://wg21.link/p1436r1
+[p1436r2]: https://wg21.link/p1436r2
 [d1436-latest]: cpp-23/d1436r2.md
 
 [p1795r0]: https://wg21.link/p1795r0
+[p1795r1]: https://wg21.link/p1795r1
 [d1795-latest]: cpp-23/d1795r1.md


### PR DESCRIPTION
* Update links for P1436r2 and P1795r1.
* Create new revisions for D1436r3 and D1795r2.
* Update readme and index.